### PR TITLE
💩 WIP: docker compose draft for Ronnie to complete

### DIFF
--- a/Dockerfile.miner
+++ b/Dockerfile.miner
@@ -1,0 +1,25 @@
+# Use official Python 3.10 slim image for smaller footprint
+FROM python:3.10-slim
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy your application's dependency file into the container
+COPY requirements.txt .
+
+# Copy application code into the container
+# 🚨 TODO: tell the buildfile which files to bundle into the container. They will be put into the /app dir. Use syntax as in the requirements line above
+COPY ... .
+
+# Expose relevant ports, note: this is documentation only, it does not make the ports accessible
+EXPOSE 8092
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of your application code
+COPY . .
+
+# Default command to run your app
+ENTRYPOINT [ "python", "neurons/miner.py" ]
+CMD [ "--netuid", "279", "--subtensor.network", "test", "--wallet.name", "sybil_test", "--wallet.hotkey", "miner2", "--logging.info", "--axon.port", "8092" ]

--- a/Dockerfile.validator
+++ b/Dockerfile.validator
@@ -1,0 +1,25 @@
+# Use official Python 3.10 slim image for smaller footprint
+FROM python:3.10-slim
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy your application's dependency file into the container
+COPY requirements.txt .
+
+# Copy application code into the container
+# 🚨 TODO: tell the buildfile which files to bundle into the container. They will be put into the /app dir. Use syntax as in the requirements line above
+COPY ... .
+
+# Expose relevant ports, note: this is documentation only, it does not make the ports accessible
+EXPOSE 9000
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of your application code
+COPY . .
+
+# Default command to run your app
+ENTRYPOINT [ "python", "neurons/validator.py" ]
+CMD [ "--netuid", "279", "--subtensor.network", "test", "--wallet.name", "sybil_test", "--wallet.hotkey", "validator1", "--logging.info", "--axon.port", "9000" ]

--- a/docker-compose.miner.yml
+++ b/docker-compose.miner.yml
@@ -1,0 +1,25 @@
+version: '3.7'
+
+services:
+
+  # Bittensor validator
+  miner:
+    container_name: miner
+    build:
+      context: .
+      dockerfile: Dockerfile.miner
+    ports:
+        - "8092:8092"
+
+  # Validator off chain scoring container
+  responder:
+    container_name: responder
+    build:
+      context: node-stack/miner
+      dockerfile: Dockerfile
+    ports:
+        - "3001:3001"
+    # You may also create a .env file in the same folder as the docker-compose.yml file
+    environment:
+        LOG_LEVEL: info
+

--- a/docker-compose.validator.yml
+++ b/docker-compose.validator.yml
@@ -1,0 +1,37 @@
+version: '3.7'
+
+services:
+
+  # Bittensor validator
+  validator:
+    container_name: validator
+    build:
+      context: .
+      dockerfile: Dockerfile.validator
+    ports:
+        - "9000:9000"
+
+  # Validator off chain scoring container
+  scoring:
+    container_name: scoring
+    build:
+      context: node-stack/validator
+      dockerfile: Dockerfile
+    ports:
+        - "3000:3000"
+    # You may also create a .env file in the same folder as the docker-compose.yml file
+    environment:
+        LOG_LEVEL: info
+        MAXMIND_LICENSE_KEY:
+        PUBLIC_URL: "http://validator:3000"
+        IP2LOCATION_DOWNLOAD_TOKEN: 
+    volumes:
+        - ./database.sqlite:/app/database.sqlite 
+        # - ./node_modules/geoip-lite/data:/app/node_modules/geoip-lite/data
+        - maxmind_data:/app/node_modules/geoip-lite/data
+        # - ./IP2LOCATION-LITE-ASN.IPV6.BIN:/app/IP2LOCATION-LITE-ASN.IPV6.BIN
+        - ip2location_data:/app/ip2location_data
+
+volumes:
+    maxmind_data:
+    ip2location_data:


### PR DESCRIPTION
As discussed a draft of docker compose files for you to use as a scaffold. What needs to be edited:

- [ ] `Dockerfile.miner` and `Dockerfile.validator` need to have their `COPY` lines edited. This line controls which files are copies into the container when it is built
- [ ] A check needs to be done on whether all needed ports are exposed. By default any docker container can make outgoing connections but NOT incoming, for that the `ports` key in the `yml` needs to be edited. The `EXPOSE` lines in the Dockerfiles is purely for documentation purposes
- [ ] I expect that the wallet keys need to be available in the  container. I am not sure how this works in Subnet miners/validators, but probably you'll need to mount the key using the `volumes` key. I recommend looking at `node-stack/validator/docker-compose.yml` and the database line. The syntax is `./host-filesystem/path:/app/inside-container-path`

Note that if needed you can set environment variables using the `environment` key and if you need to override the `CMD` line in the dockerfile you can do so without rebuilding with the `command` key which overrides the `CMD`.


**How to run**

1. When you made any changes to the Dockerfile or python files, run `docker compose build -f docker-compose.miner/validator.yml --no-cache
` (the `--no-cache` forces the files to be copied again because compose build only checks for Dockerfile changes)
2. Run `docker compose up -f docker-compose.miner/validator.yml` to see the container logs live or `docker compose up -f docker-compose.miner/validator.yml -d` and the `docker compose logs -f` to trail the logs but keep the containers running if you close the log view