### PR TITLE
Fix race conditions that appear on larget node networks

### DIFF
--- a/node-stack/validator/app.js
+++ b/node-stack/validator/app.js
@@ -28,6 +28,10 @@ await update_ip2location_bin().catch( e => log.error( e ) )
 log.info( `Updating ip2location database every ${ update_interval_ms / 1000 / 60 / 60 } hours` )
 setInterval( update_ip2location_bin, update_interval_ms )
 
+// On restart, delete old interfaces
+import { clean_up_tpn_interfaces } from './modules/wireguard.js'
+await clean_up_tpn_interfaces()
+
 // Import express
 import { app } from './routes/server.js'
 

--- a/node-stack/validator/modules/wireguard.js
+++ b/node-stack/validator/modules/wireguard.js
@@ -23,8 +23,8 @@ export async function wait_for_ip_free( { ip_address, timeout_s=test_timeout_sec
     if( !ip_address ) throw new Error( `No ip address provided` )
 
     // Check if the ip address is already in use
-    const { stdout='', stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
-    let ip_taken = stdout.includes( ip_address )
+    const { stdout, stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
+    let ip_taken = stdout?.includes( ip_address )
 
     // If ip not taken, return out
     if( !ip_taken ) return true
@@ -37,8 +37,8 @@ export async function wait_for_ip_free( { ip_address, timeout_s=test_timeout_sec
         log.info( `IP address ${ ip_address } is in use, waiting ${ interval / 1000 }s (waited for ${ waited_for / 1000 }s) for it to become free...` )
         await wait( interval )
         waited_for += interval
-        const { stdout='', stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
-        ip_taken = stdout.includes( ip_address )
+        const { stdout, stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
+        ip_taken = stdout?.includes( ip_address )
         if( !ip_taken ) break
     }
 
@@ -78,8 +78,8 @@ export async function clean_up_tpn_interfaces( { interfaces, ip_addresses, dryru
     if( ip_addresses ) {
         log.info( `Getting all interfaces associated with ip addresses:`, ip_addresses )
         const interfaces_of_ips = await Promise.all( ip_addresses.map( ip => {
-            const { stdout='' } = run( `ip addr show | grep ${ ip } |  awk -F' ' '{print $2}'` )
-            if( stdout.includes( 'tpn' ) ) return stdout.trim()
+            const { stdout } = run( `ip addr show | grep ${ ip } |  awk -F' ' '{print $2}'` )
+            if( stdout?.includes( 'tpn' ) ) return stdout.trim()
             return null
         } ) ).split( '\n' ).filter( line => line?.includes( 'tpn' ) ).trim()
         log.info( `Found interfaces associated with ip addresses:`, interfaces_of_ips )

--- a/node-stack/validator/modules/wireguard.js
+++ b/node-stack/validator/modules/wireguard.js
@@ -23,7 +23,7 @@ export async function wait_for_ip_free( { ip_address, timeout_s=test_timeout_sec
     if( !ip_address ) throw new Error( `No ip address provided` )
 
     // Check if the ip address is already in use
-    const { stdout, stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
+    const { stdout='', stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
     let ip_taken = stdout.includes( ip_address )
 
     // If ip not taken, return out
@@ -37,7 +37,7 @@ export async function wait_for_ip_free( { ip_address, timeout_s=test_timeout_sec
         log.info( `IP address ${ ip_address } is in use, waiting ${ interval / 1000 }s (waited for ${ waited_for / 1000 }s) for it to become free...` )
         await wait( interval )
         waited_for += interval
-        const { stdout, stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
+        const { stdout='', stderr } = await run( `ip addr show | grep ${ ip_address }`, false )
         ip_taken = stdout.includes( ip_address )
         if( !ip_taken ) break
     }
@@ -78,10 +78,10 @@ export async function clean_up_tpn_interfaces( { interfaces, ip_addresses, dryru
     if( ip_addresses ) {
         log.info( `Getting all interfaces associated with ip addresses:`, ip_addresses )
         const interfaces_of_ips = await Promise.all( ip_addresses.map( ip => {
-            const { stdout } = run( `ip addr show | grep ${ ip } |  awk -F' ' '{print $2}'` )
+            const { stdout='' } = run( `ip addr show | grep ${ ip } |  awk -F' ' '{print $2}'` )
             if( stdout.includes( 'tpn' ) ) return stdout.trim()
             return null
-        } ) ).split( '\n' ).filter( line => line.includes( 'tpn' ) ).trim()
+        } ) ).split( '\n' ).filter( line => line?.includes( 'tpn' ) ).trim()
         log.info( `Found interfaces associated with ip addresses:`, interfaces_of_ips )
         interfaces = interfaces ? [ ...interfaces, ...interfaces_of_ips ] : interfaces_of_ips
     }

--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/package.json
+++ b/node-stack/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-subnet-validator",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "app.js",
   "type": "module",
   "scripts": {

--- a/node-stack/validator/routes/challenge-response.js
+++ b/node-stack/validator/routes/challenge-response.js
@@ -153,7 +153,8 @@ router.post( "/:challenge/:response", async ( req, res ) => {
         // Score based on delay, with a grace period, and a punishment per ms above it
         log.info( `Time to solve ${ challenge }: ${ ms_to_solve } (${ solved_at })` )
         const s_to_solve = ms_to_solve / 1000
-        const penalty = Math.min( 100, 2 ** s_to_solve - 1 )
+        const grace_secs = 45
+        const penalty = Math.min( 100, 1.1 ** ( grace_secs - s_to_solve ) )
         const speed_score = Math.sqrt( 100 - penalty )
 
         // Uniqeness score, minus maximum speed score, plus speed score


### PR DESCRIPTION
Wireguard private subnet ips may not be duplicated on one machine, but this is likely in a distributed network like ours. Added a ip hold check in case of interface clashes on the ip addresses incoming in the miner peer config.

@thearvee when tested on testnet feel free to merge. Testnet requirements: no catastrophic explosions. Remember to use `-dev` tags and no build.