### PR TITLE
✨ in memory worker wireguard, opt-in, come algo improvements

### DIFF
--- a/federated-container/modules/api/mining_pool.js
+++ b/federated-container/modules/api/mining_pool.js
@@ -53,7 +53,7 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
     }
 
     // On mock success
-    if( CI_MOCK_MINING_POOL_RESPONSES === 'true' ) config = config || format === 'json' ? { endpoint_ipv4: 'mock.mock.mock.mock' } : `Mock ${ type } config`
+    if( CI_MOCK_MINING_POOL_RESPONSES === 'true' ) config = format === 'json' ? { endpoint_ipv4: 'mock.mock.mock.mock' } : `Mock ${ type } config`
     
     // Return the config
     return config

--- a/federated-container/modules/database/worker_wireguard.js
+++ b/federated-container/modules/database/worker_wireguard.js
@@ -1,7 +1,7 @@
 import { cache, log, wait } from "mentie"
 import { get_pg_pool } from "./postgres.js"
-import { delete_wireguard_configs, restart_wg_container, wireguard_server_ready } from "../networking/wg-container.js"
-const { WIREGUARD_PEER_COUNT=254 } = process.env 
+import { delete_wireguard_configs, replace_wireguard_configs, restart_wg_container, wireguard_server_ready } from "../networking/wg-container.js"
+const { WIREGUARD_PEER_COUNT=254, BETA_REFRESH_LEASE_INSTEAD_OF_DELETE } = process.env 
 
 async function cleanup_expired_wireguard_configs() {
 
@@ -15,7 +15,9 @@ async function cleanup_expired_wireguard_configs() {
     // Delete all expired rows and their associated configs
     const expired_ids = expired_rows.rows.map( row => row.id )
     log.debug( `Expired ids: ${ expired_ids.length } of ${ WIREGUARD_PEER_COUNT }` )
-    if( expired_ids.length > 0 ) {
+
+    // Initial approach, delete configs and restart the container
+    if( !BETA_REFRESH_LEASE_INSTEAD_OF_DELETE && expired_ids.length > 0 ) {
 
         log.info( `${ expired_ids.length } WireGuard configs have expired, deleting them and restarting server` )
 
@@ -28,6 +30,20 @@ async function cleanup_expired_wireguard_configs() {
         if( !open_leases.length ) await restart_wg_container()
         else log.info( `Not restarting wg container as there are still ${ open_leases.length } open leases` )
 
+        // Delete the expired rows from the database
+        await pool.query( `DELETE FROM worker_wireguard_configs WHERE id = ANY( $1::int[] )`, [ expired_ids ] )
+
+    }
+
+    // Beta approach, just replace config keys in memory to prevent restarts
+    if( BETA_REFRESH_LEASE_INSTEAD_OF_DELETE === 'true' && expired_ids.length > 0 ) {
+
+        log.info( `${ expired_ids.length } WireGuard configs have expired, refreshing their keys in memory` )
+
+        // Replace the configs in memory
+        await replace_wireguard_configs( { peer_ids: expired_ids } )
+        log.info( `Refreshed WireGuard configs for expired leases: ${ expired_ids.join( ', ' ) }` )
+        
         // Delete the expired rows from the database
         await pool.query( `DELETE FROM worker_wireguard_configs WHERE id = ANY( $1::int[] )`, [ expired_ids ] )
 

--- a/federated-container/modules/scoring/score_mining_pools.js
+++ b/federated-container/modules/scoring/score_mining_pools.js
@@ -222,8 +222,8 @@ async function score_single_mining_pool( { mining_pool_uid, mining_pool_ip } ) {
     if( selected_workers.length ) stability_fraction = successes.length / selected_workers.length 
     const stability_score = stability_fraction * 100
 
-    // Calculate size score, defined as the ranking of the size against the last_known_worker_pool_size 
-    const size_score = last_known_worker_pool_size * stability_fraction
+    // Calculate size score, defined as the ranking of the size against the known up worker count 
+    const size_score = workers?.length * stability_fraction
 
     // Calculate performance score
     const no_response_penalty_s = 60


### PR DESCRIPTION
This release creates the `BETA_REFRESH_LEASE_INSTEAD_OF_DELETE` env variable that enables in-memory wireguard config updating, meaning no more wg restarts.

It also upgrades some underlying algo fixes that impact scoring and node count.