### PR TITLE
:ambulance: Handle tuple

### DIFF
--- a/sybil/base/validator.py
+++ b/sybil/base/validator.py
@@ -282,11 +282,19 @@ class BaseValidatorNeuron(BaseNeuron):
                 wait_for_inclusion=False,
                 version_key=self.spec_version,
             )
-            if response.success:
+            # Check if response is a tuple (as expected in bittensor 9.10.1)
+            if isinstance(response, tuple):
+                success, message = response
+            else:
+                # Fallback for forward compatibility or if return type changes
+                success = getattr(response, "success", True)
+                message = getattr(response, "message", "")
+
+            if success:
                 bt.logging.info("set_weights on chain successfully!")
                 break
             else:
-                bt.logging.error(f"set_weights failed. Retrying... {response.message}")
+                bt.logging.error(f"set_weights failed. Retrying... {message}")
 
     def resync_metagraph(self):
         """Resyncs the metagraph and updates the hotkeys and moving averages based on the new metagraph."""


### PR DESCRIPTION
The validator encountered an AttributeError during the set_weights operation. This occurred because the bittensor library(v9.10.1) updated the return signature of subtensor.set_weights to return a tuple (success, message) instead of an object with attributes.

The fix updates validator.py to correctly unpack the response. It now detects if the return value is a tuple or an object.

