### PR TITLE
miner: optimize sync architecture, robustness, and logs

### DIFF
--- a/sybil/utils/config.py
+++ b/sybil/utils/config.py
@@ -84,7 +84,7 @@ def add_args(cls, parser):
     parser.add_argument(
         "--neuron.epoch_length",
         type=int,
-        help="The default epoch length (blocks).",
+        help="The default epoch length (how often we set weights, measured in 12 second blocks).",
         default=360,
     )
 


### PR DESCRIPTION
This PR overhauls the Miner's concurrency model and error handling to ensure stability in production. It resolves the critical ConcurrencyError by moving to a single-threaded architecture and adds self-healing logic for network transients.

**Key Changes:**

1. Architecture Fix (Single-Threaded):
**Disabled Background Thread:** Overrode Miner.run() to sit idle. This prevents the background thread from racing with the main asyncio loop for subtensor access (fixing ConcurrencyError: cannot call recv while another thread is running).
**Foreground Initialization:** Moved sync(), serve(), and start() into the main periodic_broadcast loop to ensure a sequential, safe startup.

2. Robustness (Self-Healing):
**Retry Logic:** Wrapped the main loop in a try/except block. Transient network errors (e.g., connection reset) now trigger a 5s retry sleep instead of crashing the entire miner process.
**Startup Safety:** Critical startup failures (e.g., port binding) still exit to allow PM2 to restart, preserving the "fail fast" behavior where appropriate.
**Polish & Logging:** Asyncio Fix: Replaced deprecated asyncio.get_event_loop() with asyncio.get_running_loop() to silence Python 3.12 warnings.
**Log Noise Filter:** Added UnknownSynapseFilter to catch and downgrade bittensor's scary UnknownSynapseError logs (from scanners/bots) into clean "🛡️ Ignored unsupported synapse" warnings.
**Config:** Restored original help text for epoch_length and validated defaults.

3. Testing:
* Verified on Testnet (Finney).
* Confirmed logs show clean "Initializing -> Started -> Running" sequence.
* Confirmed ConcurrencyError is gone during re-sync.