### PR TITLE
✨ add MaxMind Insights web API support to ip_geodata

### DIFF
--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -7,6 +7,12 @@
 - add `ip_geodata_cache` table for persistent geodata caching with 30-day expiry
 - store extra MaxMind traits (userType, connectionType, userCount) in cache table
 
+### Fixed
+- fix package-lock.json version mismatch (1.3.3 → 1.4.0)
+- fix in-memory cache TTL on MaxMind fallback suppressing retries for 30 days (now 5 min)
+- add `ip_geodata_cache` to periodic database cleanup to prevent unbounded table growth
+- fix cleanup guard skipping tables with `max_stale_minutes: 0`
+
 ### Changed
 - `ip_geodata` now checks postgres cache before falling back to geoip-lite
 - graceful fallback to geoip-lite when MaxMind API is unavailable or errors

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.5.0] - 2026-04-07
+
+### Added
+- validator-to-validator geodata fallback when MaxMind fails
+- `GET /validator/broadcast/geodata/:ip` endpoint for peer cache lookups
+- validator 0 prioritised as first fallback peer
+
 ## [1.4.0] - 2026-04-01
 
 ### Added

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - validator-to-validator geodata fallback when MaxMind fails
 - `GET /validator/broadcast/geodata/:ip` endpoint for peer cache lookups
-- validator 0 prioritised as first fallback peer
+- race all validator peers concurrently for fastest geodata response
 
 ## [1.4.0] - 2026-04-01
 

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.1] - 2026-04-13
+
+### Fixed
+- resolve peer geodata requests through advertised validator public endpoints
+- sanitise worker IPs before geodata lookups use miner-supplied values
+
 ## [1.5.0] - 2026-04-07
 
 ### Added

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.3] - 2026-04-13
+
+### Fixed
+- drop malformed worker entries before validator broadcast preprocessing
+- skip mining pool URL resolution for empty worker URL values
+
 ## [1.5.2] - 2026-04-13
 
 ### Fixed

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.4.0] - 2026-04-01
+
+### Added
+- add MaxMind Insights web API support to `ip_geodata` with multi-layer caching (in-memory → postgres → API)
+- add `ip_geodata_cache` table for persistent geodata caching with 30-day expiry
+- store extra MaxMind traits (userType, connectionType, userCount) in cache table
+
+### Changed
+- `ip_geodata` now checks postgres cache before falling back to geoip-lite
+- graceful fallback to geoip-lite when MaxMind API is unavailable or errors
+
 ## [1.3.3] - 2026-04-01
 
 ### Fixed

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.5.2] - 2026-04-13
+
+### Fixed
+- keep authoritative geodata cache hits on long TTL when MaxMind is enabled
+- track geodata cache source so validator fallback stays on short retry TTL
+
 ## [1.5.1] - 2026-04-13
 
 ### Fixed

--- a/federated-container/modules/database/cleanup.js
+++ b/federated-container/modules/database/cleanup.js
@@ -24,6 +24,7 @@ export async function database_cleanup() {
         { table: 'worker_performance', time_field: 'updated_at', max_stale_minutes: year_in_mins },
         { table: 'worker_broadcast_metadata', time_field: 'updated', max_stale_minutes: epoch_minutes },
         { table: 'challenge_solution', time_field: 'updated', max_stale_minutes: epoch_minutes },
+        { table: 'ip_geodata_cache', time_field: 'expires_at', max_stale_minutes: 0 },
     ]
     const validator_tables = [
         { table: 'mining_pool_metadata_broadcast', time_field: 'updated', max_stale_minutes: epoch_minutes },
@@ -44,7 +45,7 @@ export async function database_cleanup() {
         // For each table, delete stale entries
         for( const { table, max_stale_minutes, time_field } of STALENESS_THRESHOLDS ) {
 
-            if( !table || !max_stale_minutes || !time_field ) continue
+            if( !table || max_stale_minutes == null || !time_field ) continue
 
             // Calculate threshold time
             const threshold_time = Date.now() -  max_stale_minutes * 60_000 

--- a/federated-container/modules/database/init.js
+++ b/federated-container/modules/database/init.js
@@ -24,6 +24,7 @@ export async function init_database() {
         await pool.query( `DROP TABLE IF EXISTS challenge_solution` )
         await pool.query( `DROP TABLE IF EXISTS scores` )
         await pool.query( `DROP TABLE IF EXISTS worker_wireguard_configs` )
+        await pool.query( `DROP TABLE IF EXISTS ip_geodata_cache` )
     }
 
     // Enable extension that can sample rows randomly
@@ -215,6 +216,27 @@ export async function init_database() {
 
         // Speed up expired lease lookups and cleanup deletes
         await pool.query( `CREATE INDEX IF NOT EXISTS idx_socks5_expires_at ON worker_socks5_configs ( expires_at )` )
+    }
+
+    // Create the IP_GEODATA_CACHE table for caching MaxMind / geoip results
+    if( miner_mode || validator_mode ) {
+        await pool.query( `
+            CREATE TABLE IF NOT EXISTS ip_geodata_cache (
+                ip TEXT PRIMARY KEY,
+                country TEXT,
+                datacenter BOOLEAN NOT NULL DEFAULT FALSE,
+                connection_type TEXT NOT NULL DEFAULT 'unknown',
+                user_type TEXT,
+                connection_type_raw TEXT,
+                user_count INTEGER,
+                updated_at BIGINT NOT NULL,
+                expires_at BIGINT NOT NULL
+            )
+        ` )
+        log.info( `✅ IP geodata cache table initialized` )
+
+        // Speed up expired entry lookups and cleanup
+        await pool.query( `CREATE INDEX IF NOT EXISTS idx_ip_geodata_cache_expires_at ON ip_geodata_cache ( expires_at )` )
     }
 
     // Create the TIMESTAMPS table if it doesn't exist

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -135,7 +135,7 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
  *   1. In-memory cache
  *   2. PostgreSQL cache
  *   3. MaxMind Insights API (when credentials are configured)
- *   4. Peer validators (ask other validators for their cached MaxMind data)
+ *   4. Peer validators (ask other validators for their cached geodata)
  *   5. geoip-lite + ip2location (local fallback)
  *
  * When `authoritative_only` is true, only layers 1-3 are used — this prevents
@@ -234,14 +234,14 @@ async function ip_geodata_from_maxmind( ip ) {
 
 /**
  * Resolve geodata by querying peer validators for their cached data.
- * Tries validator 0 first (highest priority), then remaining peers concurrently.
+ * Races all peers concurrently via Promise.any — first successful response wins.
  * Returns null if no peer has cached data for the IP.
  */
 async function ip_geodata_from_validators( ip ) {
 
     try {
 
-        // Dynamic imports to avoid circular dependency (validations.js → helpers.js)
+        // Dynamic imports to avoid circular dependency (validators.js → helpers.js)
         const { abort_controller } = await import( 'mentie' )
         const { get_validators } = await import( '../networking/validators.js' )
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -233,6 +233,37 @@ async function ip_geodata_from_maxmind( ip ) {
 
 
 /**
+ * Resolve the public geodata endpoint for a peer validator.
+ * Uses the validator's advertised public protocol/host/port, mirroring the
+ * rest of the validator broadcast flow.
+ * @param {Object} peer - Validator peer metadata.
+ * @returns {Promise<string>} Peer geodata endpoint URL.
+ */
+async function get_validator_geodata_endpoint( peer ) {
+
+    const endpoint_cache_key = `validator:geodata_endpoint:${ peer.ip }`
+    const cached_endpoint = cache( endpoint_cache_key )
+    if( cached_endpoint ) return cached_endpoint
+
+    const { abort_controller } = await import( 'mentie' )
+    const { fetch_options } = abort_controller( { timeout_ms: 5_000 } )
+
+    const health_res = await fetch( `http://${ peer.ip }:3000/`, fetch_options )
+    if( !health_res.ok ) throw new Error( `Peer ${ peer.ip } metadata returned ${ health_res.status }` )
+
+    const health_data = await health_res.json()
+    const protocol = health_data.SERVER_PUBLIC_PROTOCOL || `http`
+    const host = health_data.SERVER_PUBLIC_HOST || peer.ip
+    const port = health_data.SERVER_PUBLIC_PORT || 3000
+    const endpoint = `${ protocol }://${ host }:${ port }/validator/broadcast/geodata`
+
+    cache( endpoint_cache_key, endpoint, 5 * 60 * 1000 )
+    return endpoint
+
+}
+
+
+/**
  * Resolve geodata by querying peer validators for their cached data.
  * Races all peers concurrently via Promise.any — first successful response wins.
  * Returns null if no peer has cached data for the IP.
@@ -258,7 +289,9 @@ async function ip_geodata_from_validators( ip ) {
         // Query a single peer with a 5-second timeout
         const query_peer = async ( peer ) => {
             const { fetch_options } = abort_controller( { timeout_ms: 5_000 } )
-            const res = await fetch( `http://${ peer.ip }:3000/validator/broadcast/geodata/${ ip }`, fetch_options )
+            const peer_geodata_endpoint = await get_validator_geodata_endpoint( peer )
+            const geodata_url = `${ peer_geodata_endpoint }/${ encodeURIComponent( ip ) }`
+            const res = await fetch( geodata_url, fetch_options )
             if( !res.ok ) throw new Error( `Peer ${ peer.ip } returned ${ res.status }` )
             const body = await res.json()
             if( !body?.success || !body?.data ) throw new Error( `Peer ${ peer.ip } has no data` )

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -138,10 +138,15 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
  *   4. Peer validators (ask other validators for their cached MaxMind data)
  *   5. geoip-lite + ip2location (local fallback)
  *
+ * When `authoritative_only` is true, only layers 1-3 are used — this prevents
+ * recursive validator-to-validator calls and avoids low-fidelity geoip-lite data.
+ *
  * @param {string} ip - The IP address to lookup.
- * @returns {Promise<{ country_code: string, datacenter: boolean, connection_type: string }>}
+ * @param {Object} [options] - Options object.
+ * @param {boolean} [options.authoritative_only=false] - Skip peer validators and geoip-lite fallback.
+ * @returns {Promise<{ country_code: string, datacenter: boolean, connection_type: string }|null>}
  */
-export async function ip_geodata( ip ) {
+export async function ip_geodata( ip, { authoritative_only = false } = {} ) {
 
     const cache_key = `geoip:${ ip }`
     let geodata = null
@@ -159,6 +164,9 @@ export async function ip_geodata( ip ) {
         geodata = result?.data
         maxmind_extras = result?.extras
     }
+
+    // In authoritative-only mode, return null if layers 1-3 had no data
+    if( authoritative_only && !geodata ) return null
 
     // --- Layer 4: peer validators ---
     if( !geodata ) geodata = await ip_geodata_from_validators( ip )

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -43,6 +43,7 @@ export const datacenter_patterns = [
 // Cache expiration: 30 days in milliseconds
 const GEODATA_CACHE_EXPIRY_DAYS = 30
 const GEODATA_CACHE_EXPIRY_MS = GEODATA_CACHE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+const GEODATA_FALLBACK_CACHE_EXPIRY_MS = 5 * 60 * 1000
 
 // Check if MaxMind web service credentials are configured
 const { MAXMIND_ACCOUNT_ID, MAXMIND_LICENSE_KEY } = process.env
@@ -68,7 +69,7 @@ export async function get_db_cached_geodata( ip ) {
 
         if( !rows.length ) return null
 
-        const row = rows[0]
+        const [ row ] = rows
         return {
             country_code: row.country,
             datacenter: row.datacenter,
@@ -129,6 +130,37 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
 
 
 /**
+ * Cache geodata in memory together with the source that produced it.
+ * @param {Object} options
+ * @param {string} options.ip - IP address used for the cache key.
+ * @param {Object} options.geodata - Geodata payload to cache.
+ * @param {string} options.source - Resolution source for this payload.
+ * @param {number} options.ttl - Cache TTL in milliseconds.
+ */
+function save_memory_cached_geodata( { ip, geodata, source, ttl } ) {
+
+    cache( `geoip:${ ip }`, geodata, ttl )
+    cache( `geoip_source:${ ip }`, source, ttl )
+
+}
+
+
+/**
+ * Returns true when a source should keep only a short in-memory TTL so MaxMind
+ * can be retried soon after recovery.
+ * @param {string} source - Resolution source.
+ * @returns {boolean} Whether the source is a fallback.
+ */
+function is_fallback_source( source ) {
+
+    if( source === `validator` ) return true
+    if( source === `geoip_lite` && maxmind_insights_enabled ) return true
+    return false
+
+}
+
+
+/**
  * Get geolocation data for an IP address.
  *
  * Resolution layers (first hit wins):
@@ -149,42 +181,64 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
 export async function ip_geodata( ip, { authoritative_only = false } = {} ) {
 
     const cache_key = `geoip:${ ip }`
+    const cache_source_key = `geoip_source:${ ip }`
     let geodata = null
+    let geodata_source = null
     let maxmind_extras = null
 
     // --- Layer 1: in-memory cache ---
     geodata = cache( cache_key )
+    geodata_source = cache( cache_source_key ) || `memory`
+
+    // Keep fallback cache entries out of authoritative-only responses, and
+    // avoid resetting TTLs or rewriting DB state on memory hits.
+    if( geodata && ( !authoritative_only || !is_fallback_source( geodata_source ) ) ) return geodata
+    geodata = null
+    geodata_source = null
 
     // --- Layer 2: database cache ---
-    if( !geodata ) geodata = await get_db_cached_geodata( ip )
+    if( !geodata ) {
+        geodata = await get_db_cached_geodata( ip )
+        if( geodata ) geodata_source = `db`
+    }
 
     // --- Layer 3: MaxMind Insights API ---
     if( !geodata && maxmind_insights_enabled ) {
         const result = await ip_geodata_from_maxmind( ip )
         geodata = result?.data
         maxmind_extras = result?.extras
+        if( geodata ) geodata_source = `maxmind`
     }
 
     // In authoritative-only mode, return null if layers 1-3 had no data
     if( authoritative_only && !geodata ) return null
 
     // --- Layer 4: peer validators ---
-    if( !geodata ) geodata = await ip_geodata_from_validators( ip )
+    if( !geodata ) {
+        geodata = await ip_geodata_from_validators( ip )
+        if( geodata ) geodata_source = `validator`
+    }
 
     // --- Layer 5: geoip-lite (final fallback) ---
-    if( !geodata ) geodata = await ip_geodata_from_geoip_lite( ip )
+    if( !geodata ) {
+        geodata = await ip_geodata_from_geoip_lite( ip )
+        if( geodata ) geodata_source = `geoip_lite`
+    }
 
 
     // --- Persist and cache the result ---
-    // MaxMind results get full DB persistence and 30-day TTL.
-    // geoip-lite as primary source (no MaxMind configured) also gets full persistence.
-    // Fallback results (validators, geoip-lite when MaxMind failed) get a short 5-minute
-    // in-memory TTL so MaxMind is retried after recovery.
-    const is_authoritative = !!maxmind_extras || !maxmind_insights_enabled
-    const ttl = is_authoritative ? GEODATA_CACHE_EXPIRY_MS : 5 * 60 * 1000
+    // Memory hits have already returned earlier, so this section handles
+    // database-backed or freshly resolved data.
+    // MaxMind results and geoip-lite as the primary source keep the long TTL.
+    // True fallback sources (validators, geoip-lite when MaxMind is enabled)
+    // get a short in-memory TTL so MaxMind is retried after recovery.
+    const ttl = is_fallback_source( geodata_source ) ? GEODATA_FALLBACK_CACHE_EXPIRY_MS : GEODATA_CACHE_EXPIRY_MS
 
-    if( is_authoritative ) await save_db_cached_geodata( ip, geodata, maxmind_extras )
-    cache( cache_key, geodata, ttl )
+    if( geodata_source === `maxmind` || ( geodata_source === `geoip_lite` && !maxmind_insights_enabled ) ) {
+        await save_db_cached_geodata( ip, geodata, maxmind_extras )
+    }
+
+    save_memory_cached_geodata( { ip, geodata, source: geodata_source, ttl } )
 
     return geodata
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -199,11 +199,13 @@ async function ip_geodata_from_maxmind( ip ) {
 
     try {
 
-        const { WebServiceClient } = await import( '@maxmind/geoip2-node' )
-
-        const client = new WebServiceClient( MAXMIND_ACCOUNT_ID, MAXMIND_LICENSE_KEY, {
-            timeout: 5000,
-        } )
+        // Reuse a single WebServiceClient instance across calls
+        let client = cache( `maxmind:client` )
+        if( !client ) {
+            const { WebServiceClient } = await import( '@maxmind/geoip2-node' )
+            client = new WebServiceClient( MAXMIND_ACCOUNT_ID, MAXMIND_LICENSE_KEY, { timeout: 5000 } )
+            cache( `maxmind:client`, client )
+        }
 
         const response = await client.insights( ip )
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -54,7 +54,7 @@ const maxmind_insights_enabled = !!MAXMIND_ACCOUNT_ID && !!MAXMIND_LICENSE_KEY
  * @param {string} ip - The IP address to look up.
  * @returns {Promise<object|null>} - Cached row or null if not found / expired.
  */
-async function get_db_cached_geodata( ip ) {
+export async function get_db_cached_geodata( ip ) {
 
     try {
 
@@ -204,11 +204,84 @@ async function ip_geodata_from_maxmind( ip, cache_key ) {
 
     } catch ( e ) {
 
-        // Log the error and fall back to geoip-lite (no db save on fallback)
+        // Log the error and try peer validators before falling back to geoip-lite
         log.error( `MaxMind Insights API error for ${ ip }: ${ e.message }` )
+
+        // Try to get geodata from peer validators
+        try {
+            const validator_data = await ip_geodata_from_validators( ip, cache_key )
+            if( validator_data ) return validator_data
+        } catch ( validator_err ) {
+            log.warn( `Validator geodata fallback failed for ${ ip }: ${ validator_err.message }` )
+        }
+
+        // Final fallback: geoip-lite (no db save, short TTL)
         return ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save: true } )
 
     }
+
+}
+
+
+/**
+ * Resolve geodata by querying peer validators for their cached data.
+ * Tries validator 0 first (highest priority), then remaining peers concurrently.
+ * Returns null if no peer has cached data for the IP.
+ */
+async function ip_geodata_from_validators( ip, cache_key ) {
+
+    // Dynamic imports to avoid circular dependency (validations.js → helpers.js)
+    const { abort_controller } = await import( 'mentie' )
+    const { get_validators } = await import( '../networking/validators.js' )
+
+    // Get peer validators, excluding self
+    const { SERVER_PUBLIC_HOST } = process.env
+    const all_validators = await get_validators()
+    const peers = all_validators.filter( v => v.ip !== SERVER_PUBLIC_HOST && v.ip !== '0.0.0.0' )
+
+    if( !peers.length ) {
+        log.info( `No validator peers available for geodata fallback` )
+        return null
+    }
+
+    // Helper: query a single peer with a 5-second timeout
+    const query_peer = async ( peer ) => {
+        const { fetch_options } = abort_controller( { timeout_ms: 5_000 } )
+        const res = await fetch( `http://${ peer.ip }:3000/validator/broadcast/geodata/${ ip }`, fetch_options )
+        if( !res.ok ) throw new Error( `Peer ${ peer.ip } returned ${ res.status }` )
+        const body = await res.json()
+        if( !body?.success || !body?.data ) throw new Error( `Peer ${ peer.ip } has no data` )
+        return body.data
+    }
+
+    // Try validator 0 first (highest priority fallback)
+    const validator_zero = peers.find( v => v.uid == 0 || v.uid === '0' )
+    if( validator_zero ) {
+        try {
+            const data = await query_peer( validator_zero )
+            log.info( `Got geodata for ${ ip } from validator 0 (${ validator_zero.ip })` )
+            cache( cache_key, data, 5 * 60 * 1000 )
+            return data
+        } catch ( e ) {
+            log.info( `Validator 0 geodata fallback failed for ${ ip }: ${ e.message }` )
+        }
+    }
+
+    // Try remaining peers concurrently
+    const remaining = peers.filter( v => v !== validator_zero )
+    if( !remaining.length ) return null
+
+    const results = await Promise.allSettled( remaining.map( query_peer ) )
+    const valid = results.find( r => r.status === 'fulfilled' )
+
+    if( valid ) {
+        log.info( `Got geodata for ${ ip } from validator peer` )
+        cache( cache_key, valid.value, 5 * 60 * 1000 )
+        return valid.value
+    }
+
+    log.info( `No validator peers had cached geodata for ${ ip }` )
+    return null
 
 }
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -131,17 +131,21 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
 /**
  * Get geolocation data for an IP address.
  *
- * When MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY are set, uses the MaxMind
- * Insights web API with multi-layer caching (in-memory → postgres → API).
- * Otherwise falls back to geoip-lite + ip2location with postgres caching.
+ * Resolution layers (first hit wins):
+ *   1. In-memory cache
+ *   2. PostgreSQL cache
+ *   3. MaxMind Insights API (when credentials are configured)
+ *   4. Peer validators (ask other validators for their cached MaxMind data)
+ *   5. geoip-lite + ip2location (local fallback)
  *
  * @param {string} ip - The IP address to lookup.
  * @returns {Promise<{ country_code: string, datacenter: boolean, connection_type: string }>}
  */
 export async function ip_geodata( ip ) {
 
-    // --- Layer 1: in-memory cache (both paths) ---
     const cache_key = `geoip:${ ip }`
+
+    // --- Layer 1: in-memory cache ---
     const cached_value = cache( cache_key )
     if( cached_value ) return cached_value
 
@@ -156,20 +160,33 @@ export async function ip_geodata( ip ) {
     }
 
 
-    // --- Layer 3: resolve fresh data ---
-
+    // --- Layer 3: MaxMind Insights API ---
     if( maxmind_insights_enabled ) {
-        return ip_geodata_from_maxmind( ip, cache_key )
+        const maxmind_data = await ip_geodata_from_maxmind( ip, cache_key )
+        if( maxmind_data ) return maxmind_data
     }
 
-    return ip_geodata_from_geoip_lite( ip, cache_key )
+
+    // --- Layer 4: peer validators ---
+    try {
+        const validator_data = await ip_geodata_from_validators( ip, cache_key )
+        if( validator_data ) return validator_data
+    } catch ( e ) {
+        log.warn( `Validator geodata fallback failed for ${ ip }: ${ e.message }` )
+    }
+
+
+    // --- Layer 5: geoip-lite (final fallback) ---
+    // When MaxMind is enabled but failed, skip DB save and use a short TTL so MaxMind is retried.
+    // When MaxMind is not configured, geoip-lite is the primary source and should persist normally.
+    return ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save: maxmind_insights_enabled } )
 
 }
 
 
 /**
  * Resolve geodata via the MaxMind Insights web API.
- * On failure, falls back to geoip-lite without caching to the database.
+ * Returns null on failure so the caller can proceed to the next layer.
  */
 async function ip_geodata_from_maxmind( ip, cache_key ) {
 
@@ -204,19 +221,8 @@ async function ip_geodata_from_maxmind( ip, cache_key ) {
 
     } catch ( e ) {
 
-        // Log the error and try peer validators before falling back to geoip-lite
         log.error( `MaxMind Insights API error for ${ ip }: ${ e.message }` )
-
-        // Try to get geodata from peer validators
-        try {
-            const validator_data = await ip_geodata_from_validators( ip, cache_key )
-            if( validator_data ) return validator_data
-        } catch ( validator_err ) {
-            log.warn( `Validator geodata fallback failed for ${ ip }: ${ validator_err.message }` )
-        }
-
-        // Final fallback: geoip-lite (no db save, short TTL)
-        return ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save: true } )
+        return null
 
     }
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -234,7 +234,7 @@ export async function ip_geodata( ip, { authoritative_only = false } = {} ) {
     // get a short in-memory TTL so MaxMind is retried after recovery.
     const ttl = is_fallback_source( geodata_source ) ? GEODATA_FALLBACK_CACHE_EXPIRY_MS : GEODATA_CACHE_EXPIRY_MS
 
-    if( geodata_source === `maxmind` || ( geodata_source === `geoip_lite` && !maxmind_insights_enabled ) ) {
+    if( geodata_source === `maxmind` ||  geodata_source === `geoip_lite` && !maxmind_insights_enabled  ) {
         await save_db_cached_geodata( ip, geodata, maxmind_extras )
     }
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -232,8 +232,10 @@ async function ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save = false
         await save_db_cached_geodata( ip, data )
     }
 
-    // Warm in-memory cache with a shorter TTL for the lite path
-    cache( cache_key, data, GEODATA_CACHE_EXPIRY_MS )
+    // Use a short in-memory TTL on fallback so MaxMind is retried after recovery,
+    // otherwise align with the DB cache TTL
+    const in_memory_ttl_ms = skip_db_save ? 5 * 60 * 1000 : GEODATA_CACHE_EXPIRY_MS
+    cache( cache_key, data, in_memory_ttl_ms )
 
     return data
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -1,5 +1,6 @@
 import { cache, log } from 'mentie'
 import { is_data_center } from './ip2location.js'
+import { get_pg_pool } from '../database/postgres.js'
 
 // Helper that has all country names
 export const region_names = new Intl.DisplayNames( [ 'en' ], { type: 'region' } )
@@ -24,71 +25,216 @@ export const geolocation_update_interval_ms = 60_000 * 60 * 24
 
 // Datacenter name patterns (including educated guesses)
 export const datacenter_patterns = [
-    /amazon/i,
-    /aws/i,
-    /cloudfront/i,
-    /google/i,
-    /microsoft/i,
-    /azure/i,
-    /digitalocean/i,
-    /linode/i,
-    /vultr/i,
-    /ovh/i,
-    /hetzner/i,
-    /upcloud/i,
-    /scaleway/i,
-    /contabo/i,
-    /ionos/i,
-    /rackspace/i,
-    /softlayer/i,
-    /alibaba/i,
-    /tencent/i,
-    /baidu/i,
-    /cloudflare/i,
-    /fastly/i,
-    /akamai/i,
-    /edgecast/i,
-    /level3/i,
-    /limelight/i,
-    /incapsula/i,
-    /stackpath/i,
-    /maxcdn/i,
-    /cloudsigma/i,
-    /quadranet/i,
-    /psychz/i,
-    /choopa/i,
-    /leaseweb/i,
-    /hostwinds/i,
-    /equinix/i,
-    /colocrossing/i,
-    /hivelocity/i,
-    /godaddy/i,
-    /bluehost/i,
-    /hostgator/i,
-    /dreamhost/i,
+    /amazon/i, /aws/i, /cloudfront/i, /google/i, /microsoft/i, /azure/i,
+    /digitalocean/i, /linode/i, /vultr/i, /ovh/i, /hetzner/i, /upcloud/i,
+    /scaleway/i, /contabo/i, /ionos/i, /rackspace/i, /softlayer/i,
+    /alibaba/i, /tencent/i, /baidu/i, /cloudflare/i, /fastly/i, /akamai/i,
+    /edgecast/i, /level3/i, /limelight/i, /incapsula/i, /stackpath/i,
+    /maxcdn/i, /cloudsigma/i, /quadranet/i, /psychz/i, /choopa/i,
+    /leaseweb/i, /hostwinds/i, /equinix/i, /colocrossing/i, /hivelocity/i,
+    /godaddy/i, /bluehost/i, /hostgator/i, /dreamhost/i,
     /hurricane electric/i,
     // Generic patterns indicating data centers
-    /colo/i,
-    /datacenter/i,
-    /serverfarm/i,
-    /hosting/i,
-    /cloud\s*services?/i,
-    /dedicated\s*server/i,
-    /vps/i
+    /colo/i, /datacenter/i, /serverfarm/i,
+    /hosting/i, /cloud\s*services?/i, /dedicated\s*server/i, /vps/i
 ]
 
+
+// Cache expiration: 30 days in milliseconds
+const GEODATA_CACHE_EXPIRY_DAYS = 30
+const GEODATA_CACHE_EXPIRY_MS = GEODATA_CACHE_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+
+// Check if MaxMind web service credentials are configured
+const { MAXMIND_ACCOUNT_ID, MAXMIND_LICENSE_KEY } = process.env
+const maxmind_insights_enabled = !!MAXMIND_ACCOUNT_ID && !!MAXMIND_LICENSE_KEY
+
+
 /**
- * Get geolocation data for an IP address
- * @param {string} ip - The IP address to lookup
- * @returns {Promise<{ country: string, datacenter: boolean }>} - The geolocation data
+ * Query the ip_geodata_cache table for a non-expired entry.
+ * @param {string} ip - The IP address to look up.
+ * @returns {Promise<object|null>} - Cached row or null if not found / expired.
+ */
+async function get_db_cached_geodata( ip ) {
+
+    try {
+
+        const pool = await get_pg_pool()
+        const now = Date.now()
+
+        const { rows } = await pool.query(
+            `SELECT * FROM ip_geodata_cache WHERE ip = $1 AND expires_at > $2 LIMIT 1`,
+            [ ip, now ]
+        )
+
+        if( !rows.length ) return null
+
+        const row = rows[0]
+        return {
+            country_code: row.country,
+            datacenter: row.datacenter,
+            connection_type: row.connection_type,
+        }
+
+    } catch ( e ) {
+        log.warn( `ip_geodata_cache db lookup failed for ${ ip }: ${ e.message }` )
+        return null
+    }
+
+}
+
+
+/**
+ * Save geodata to the ip_geodata_cache table (upsert).
+ * @param {string} ip - The IP address.
+ * @param {object} data - The geodata to cache.
+ * @param {object} [extras={}] - Additional MaxMind fields to store.
+ */
+async function save_db_cached_geodata( ip, data, extras = {} ) {
+
+    try {
+
+        const pool = await get_pg_pool()
+        const now = Date.now()
+        const expires_at = now + GEODATA_CACHE_EXPIRY_MS
+
+        await pool.query( `
+            INSERT INTO ip_geodata_cache ( ip, country, datacenter, connection_type, user_type, connection_type_raw, user_count, updated_at, expires_at )
+            VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9 )
+            ON CONFLICT ( ip ) DO UPDATE SET
+                country = EXCLUDED.country,
+                datacenter = EXCLUDED.datacenter,
+                connection_type = EXCLUDED.connection_type,
+                user_type = EXCLUDED.user_type,
+                connection_type_raw = EXCLUDED.connection_type_raw,
+                user_count = EXCLUDED.user_count,
+                updated_at = EXCLUDED.updated_at,
+                expires_at = EXCLUDED.expires_at
+        `, [
+            ip,
+            data.country_code || null,
+            data.datacenter,
+            data.connection_type,
+            extras.userType ?? null,
+            extras.connectionType ?? null,
+            extras.userCount ?? null,
+            now,
+            expires_at,
+        ] )
+
+    } catch ( e ) {
+        log.warn( `ip_geodata_cache db save failed for ${ ip }: ${ e.message }` )
+    }
+
+}
+
+
+/**
+ * Get geolocation data for an IP address.
+ *
+ * When MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY are set, uses the MaxMind
+ * Insights web API with multi-layer caching (in-memory → postgres → API).
+ * Otherwise falls back to geoip-lite + ip2location with postgres caching.
+ *
+ * @param {string} ip - The IP address to lookup.
+ * @returns {Promise<{ country_code: string, datacenter: boolean, connection_type: string }>}
  */
 export async function ip_geodata( ip ) {
-    const { default: geoip } = await import( 'geoip-lite' )
-    const cached_value = cache( `geoip:${ ip }` )
+
+    // --- Layer 1: in-memory cache (both paths) ---
+    const cache_key = `geoip:${ ip }`
+    const cached_value = cache( cache_key )
     if( cached_value ) return cached_value
+
+
+    // --- Layer 2: database cache ---
+    const db_cached = await get_db_cached_geodata( ip )
+
+    if( db_cached ) {
+        // Warm the in-memory cache from the db hit
+        cache( cache_key, db_cached, GEODATA_CACHE_EXPIRY_MS )
+        return db_cached
+    }
+
+
+    // --- Layer 3: resolve fresh data ---
+
+    if( maxmind_insights_enabled ) {
+        return ip_geodata_from_maxmind( ip, cache_key )
+    }
+
+    return ip_geodata_from_geoip_lite( ip, cache_key )
+
+}
+
+
+/**
+ * Resolve geodata via the MaxMind Insights web API.
+ * On failure, falls back to geoip-lite without caching to the database.
+ */
+async function ip_geodata_from_maxmind( ip, cache_key ) {
+
+    try {
+
+        const { WebServiceClient } = await import( '@maxmind/geoip2-node' )
+
+        const client = new WebServiceClient( MAXMIND_ACCOUNT_ID, MAXMIND_LICENSE_KEY, {
+            timeout: 5000,
+        } )
+
+        const response = await client.insights( ip )
+
+        const country_code = response.country?.isoCode || undefined
+        const datacenter = !!response.traits?.isHostingProvider
+        const connection_type = datacenter ? 'datacenter' : 'residential'
+
+        const data = { country_code, datacenter, connection_type }
+
+        // Extra fields stored in db but not returned
+        const extras = {
+            userType: response.traits?.userType,
+            connectionType: response.traits?.connectionType,
+            userCount: response.traits?.userCount,
+        }
+
+        // Persist to db and warm in-memory cache
+        await save_db_cached_geodata( ip, data, extras )
+        cache( cache_key, data, GEODATA_CACHE_EXPIRY_MS )
+
+        return data
+
+    } catch ( e ) {
+
+        // Log the error and fall back to geoip-lite (no db save on fallback)
+        log.error( `MaxMind Insights API error for ${ ip }: ${ e.message }` )
+        return ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save: true } )
+
+    }
+
+}
+
+
+/**
+ * Resolve geodata via geoip-lite + ip2location (the original path).
+ * By default saves to the database cache; set skip_db_save when falling back from an API error.
+ */
+async function ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save = false } = {} ) {
+
+    const { default: geoip } = await import( 'geoip-lite' )
+
     const { country } = geoip.lookup( ip ) || {}
     const datacenter = !!ip && await is_data_center( ip )
     const connection_type = datacenter ? 'datacenter' : 'residential'
+
     const data = { country_code: country, datacenter, connection_type }
-    return cache( `geoip:${ ip }`, data, 60_000 )
+
+    // Persist to db (unless this is a fallback from a failed API call)
+    if( !skip_db_save ) {
+        await save_db_cached_geodata( ip, data )
+    }
+
+    // Warm in-memory cache with a shorter TTL for the lite path
+    cache( cache_key, data, GEODATA_CACHE_EXPIRY_MS )
+
+    return data
+
 }

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -156,17 +156,12 @@ export async function ip_geodata( ip ) {
     // --- Layer 3: MaxMind Insights API ---
     if( !geodata && maxmind_insights_enabled ) {
         const result = await ip_geodata_from_maxmind( ip )
-        if( result ) {
-            geodata = result.data
-            maxmind_extras = result.extras
-        }
+        geodata = result?.data
+        maxmind_extras = result?.extras
     }
 
     // --- Layer 4: peer validators ---
-    if( !geodata ) {
-        try { geodata = await ip_geodata_from_validators( ip ) }
-        catch ( e ) { log.warn( `Validator geodata fallback failed for ${ ip }: ${ e.message }` ) }
-    }
+    if( !geodata ) geodata = await ip_geodata_from_validators( ip )
 
     // --- Layer 5: geoip-lite (final fallback) ---
     if( !geodata ) geodata = await ip_geodata_from_geoip_lite( ip )
@@ -234,56 +229,44 @@ async function ip_geodata_from_maxmind( ip ) {
  */
 async function ip_geodata_from_validators( ip ) {
 
-    // Dynamic imports to avoid circular dependency (validations.js → helpers.js)
-    const { abort_controller } = await import( 'mentie' )
-    const { get_validators } = await import( '../networking/validators.js' )
+    try {
 
-    // Get peer validators, excluding self
-    const { SERVER_PUBLIC_HOST } = process.env
-    const all_validators = await get_validators()
-    const peers = all_validators.filter( v => v.ip !== SERVER_PUBLIC_HOST && v.ip !== '0.0.0.0' )
+        // Dynamic imports to avoid circular dependency (validations.js → helpers.js)
+        const { abort_controller } = await import( 'mentie' )
+        const { get_validators } = await import( '../networking/validators.js' )
 
-    if( !peers.length ) {
-        log.info( `No validator peers available for geodata fallback` )
-        return null
-    }
+        // Get peer validators, excluding self
+        const { SERVER_PUBLIC_HOST } = process.env
+        const all_validators = await get_validators()
+        const peers = all_validators.filter( v => v.ip !== SERVER_PUBLIC_HOST && v.ip !== '0.0.0.0' )
 
-    // Helper: query a single peer with a 5-second timeout
-    const query_peer = async ( peer ) => {
-        const { fetch_options } = abort_controller( { timeout_ms: 5_000 } )
-        const res = await fetch( `http://${ peer.ip }:3000/validator/broadcast/geodata/${ ip }`, fetch_options )
-        if( !res.ok ) throw new Error( `Peer ${ peer.ip } returned ${ res.status }` )
-        const body = await res.json()
-        if( !body?.success || !body?.data ) throw new Error( `Peer ${ peer.ip } has no data` )
-        return body.data
-    }
-
-    // Try validator 0 first (highest priority fallback)
-    const validator_zero = peers.find( v => v.uid == 0 || v.uid === '0' )
-    if( validator_zero ) {
-        try {
-            const data = await query_peer( validator_zero )
-            log.info( `Got geodata for ${ ip } from validator 0 (${ validator_zero.ip })` )
-            return data
-        } catch ( e ) {
-            log.info( `Validator 0 geodata fallback failed for ${ ip }: ${ e.message }` )
+        if( !peers.length ) {
+            log.info( `No validator peers available for geodata fallback` )
+            return null
         }
-    }
 
-    // Try remaining peers concurrently
-    const remaining = peers.filter( v => v !== validator_zero )
-    if( !remaining.length ) return null
+        // Query a single peer with a 5-second timeout
+        const query_peer = async ( peer ) => {
+            const { fetch_options } = abort_controller( { timeout_ms: 5_000 } )
+            const res = await fetch( `http://${ peer.ip }:3000/validator/broadcast/geodata/${ ip }`, fetch_options )
+            if( !res.ok ) throw new Error( `Peer ${ peer.ip } returned ${ res.status }` )
+            const body = await res.json()
+            if( !body?.success || !body?.data ) throw new Error( `Peer ${ peer.ip } has no data` )
+            return body.data
+        }
 
-    const results = await Promise.allSettled( remaining.map( query_peer ) )
-    const valid = results.find( r => r.status === 'fulfilled' )
-
-    if( valid ) {
+        // Race all peers — first successful response wins
+        const data = await Promise.any( peers.map( query_peer ) )
         log.info( `Got geodata for ${ ip } from validator peer` )
-        return valid.value
-    }
+        return data
 
-    log.info( `No validator peers had cached geodata for ${ ip }` )
-    return null
+    } catch ( e ) {
+
+        // AggregateError means all peers failed, anything else is unexpected
+        log.info( `No validator peers had cached geodata for ${ ip }` )
+        return null
+
+    }
 
 }
 

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -154,7 +154,6 @@ export async function ip_geodata( ip ) {
     const db_cached = await get_db_cached_geodata( ip )
 
     if( db_cached ) {
-        // Warm the in-memory cache from the db hit
         cache( cache_key, db_cached, GEODATA_CACHE_EXPIRY_MS )
         return db_cached
     }
@@ -162,33 +161,50 @@ export async function ip_geodata( ip ) {
 
     // --- Layer 3: MaxMind Insights API ---
     if( maxmind_insights_enabled ) {
-        const maxmind_data = await ip_geodata_from_maxmind( ip, cache_key )
-        if( maxmind_data ) return maxmind_data
+        const result = await ip_geodata_from_maxmind( ip )
+        if( result ) {
+            await save_db_cached_geodata( ip, result.data, result.extras )
+            cache( cache_key, result.data, GEODATA_CACHE_EXPIRY_MS )
+            return result.data
+        }
     }
 
 
     // --- Layer 4: peer validators ---
+    // Short TTL so MaxMind is retried after recovery
     try {
-        const validator_data = await ip_geodata_from_validators( ip, cache_key )
-        if( validator_data ) return validator_data
+        const validator_data = await ip_geodata_from_validators( ip )
+        if( validator_data ) {
+            cache( cache_key, validator_data, 5 * 60 * 1000 )
+            return validator_data
+        }
     } catch ( e ) {
         log.warn( `Validator geodata fallback failed for ${ ip }: ${ e.message }` )
     }
 
 
     // --- Layer 5: geoip-lite (final fallback) ---
-    // When MaxMind is enabled but failed, skip DB save and use a short TTL so MaxMind is retried.
-    // When MaxMind is not configured, geoip-lite is the primary source and should persist normally.
-    return ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save: maxmind_insights_enabled } )
+    const geoip_data = await ip_geodata_from_geoip_lite( ip )
+
+    // When geoip-lite is the primary source (no MaxMind), persist to DB with full TTL.
+    // When it's a fallback from a failed MaxMind call, use a short TTL so MaxMind is retried.
+    if( !maxmind_insights_enabled ) {
+        await save_db_cached_geodata( ip, geoip_data )
+        cache( cache_key, geoip_data, GEODATA_CACHE_EXPIRY_MS )
+    } else {
+        cache( cache_key, geoip_data, 5 * 60 * 1000 )
+    }
+
+    return geoip_data
 
 }
 
 
 /**
  * Resolve geodata via the MaxMind Insights web API.
- * Returns null on failure so the caller can proceed to the next layer.
+ * Returns { data, extras } on success, null on failure.
  */
-async function ip_geodata_from_maxmind( ip, cache_key ) {
+async function ip_geodata_from_maxmind( ip ) {
 
     try {
 
@@ -205,19 +221,13 @@ async function ip_geodata_from_maxmind( ip, cache_key ) {
         const connection_type = datacenter ? 'datacenter' : 'residential'
 
         const data = { country_code, datacenter, connection_type }
-
-        // Extra fields stored in db but not returned
         const extras = {
             userType: response.traits?.userType,
             connectionType: response.traits?.connectionType,
             userCount: response.traits?.userCount,
         }
 
-        // Persist to db and warm in-memory cache
-        await save_db_cached_geodata( ip, data, extras )
-        cache( cache_key, data, GEODATA_CACHE_EXPIRY_MS )
-
-        return data
+        return { data, extras }
 
     } catch ( e ) {
 
@@ -234,7 +244,7 @@ async function ip_geodata_from_maxmind( ip, cache_key ) {
  * Tries validator 0 first (highest priority), then remaining peers concurrently.
  * Returns null if no peer has cached data for the IP.
  */
-async function ip_geodata_from_validators( ip, cache_key ) {
+async function ip_geodata_from_validators( ip ) {
 
     // Dynamic imports to avoid circular dependency (validations.js → helpers.js)
     const { abort_controller } = await import( 'mentie' )
@@ -266,7 +276,6 @@ async function ip_geodata_from_validators( ip, cache_key ) {
         try {
             const data = await query_peer( validator_zero )
             log.info( `Got geodata for ${ ip } from validator 0 (${ validator_zero.ip })` )
-            cache( cache_key, data, 5 * 60 * 1000 )
             return data
         } catch ( e ) {
             log.info( `Validator 0 geodata fallback failed for ${ ip }: ${ e.message }` )
@@ -282,7 +291,6 @@ async function ip_geodata_from_validators( ip, cache_key ) {
 
     if( valid ) {
         log.info( `Got geodata for ${ ip } from validator peer` )
-        cache( cache_key, valid.value, 5 * 60 * 1000 )
         return valid.value
     }
 
@@ -294,9 +302,8 @@ async function ip_geodata_from_validators( ip, cache_key ) {
 
 /**
  * Resolve geodata via geoip-lite + ip2location (the original path).
- * By default saves to the database cache; set skip_db_save when falling back from an API error.
  */
-async function ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save = false } = {} ) {
+async function ip_geodata_from_geoip_lite( ip ) {
 
     const { default: geoip } = await import( 'geoip-lite' )
 
@@ -304,18 +311,6 @@ async function ip_geodata_from_geoip_lite( ip, cache_key, { skip_db_save = false
     const datacenter = !!ip && await is_data_center( ip )
     const connection_type = datacenter ? 'datacenter' : 'residential'
 
-    const data = { country_code: country, datacenter, connection_type }
-
-    // Persist to db (unless this is a fallback from a failed API call)
-    if( !skip_db_save ) {
-        await save_db_cached_geodata( ip, data )
-    }
-
-    // Use a short in-memory TTL on fallback so MaxMind is retried after recovery,
-    // otherwise align with the DB cache TTL
-    const in_memory_ttl_ms = skip_db_save ? 5 * 60 * 1000 : GEODATA_CACHE_EXPIRY_MS
-    cache( cache_key, data, in_memory_ttl_ms )
-
-    return data
+    return { country_code: country, datacenter, connection_type }
 
 }

--- a/federated-container/modules/geolocation/helpers.js
+++ b/federated-container/modules/geolocation/helpers.js
@@ -144,58 +144,46 @@ async function save_db_cached_geodata( ip, data, extras = {} ) {
 export async function ip_geodata( ip ) {
 
     const cache_key = `geoip:${ ip }`
+    let geodata = null
+    let maxmind_extras = null
 
     // --- Layer 1: in-memory cache ---
-    const cached_value = cache( cache_key )
-    if( cached_value ) return cached_value
-
+    geodata = cache( cache_key )
 
     // --- Layer 2: database cache ---
-    const db_cached = await get_db_cached_geodata( ip )
-
-    if( db_cached ) {
-        cache( cache_key, db_cached, GEODATA_CACHE_EXPIRY_MS )
-        return db_cached
-    }
-
+    if( !geodata ) geodata = await get_db_cached_geodata( ip )
 
     // --- Layer 3: MaxMind Insights API ---
-    if( maxmind_insights_enabled ) {
+    if( !geodata && maxmind_insights_enabled ) {
         const result = await ip_geodata_from_maxmind( ip )
         if( result ) {
-            await save_db_cached_geodata( ip, result.data, result.extras )
-            cache( cache_key, result.data, GEODATA_CACHE_EXPIRY_MS )
-            return result.data
+            geodata = result.data
+            maxmind_extras = result.extras
         }
     }
-
 
     // --- Layer 4: peer validators ---
-    // Short TTL so MaxMind is retried after recovery
-    try {
-        const validator_data = await ip_geodata_from_validators( ip )
-        if( validator_data ) {
-            cache( cache_key, validator_data, 5 * 60 * 1000 )
-            return validator_data
-        }
-    } catch ( e ) {
-        log.warn( `Validator geodata fallback failed for ${ ip }: ${ e.message }` )
+    if( !geodata ) {
+        try { geodata = await ip_geodata_from_validators( ip ) }
+        catch ( e ) { log.warn( `Validator geodata fallback failed for ${ ip }: ${ e.message }` ) }
     }
-
 
     // --- Layer 5: geoip-lite (final fallback) ---
-    const geoip_data = await ip_geodata_from_geoip_lite( ip )
+    if( !geodata ) geodata = await ip_geodata_from_geoip_lite( ip )
 
-    // When geoip-lite is the primary source (no MaxMind), persist to DB with full TTL.
-    // When it's a fallback from a failed MaxMind call, use a short TTL so MaxMind is retried.
-    if( !maxmind_insights_enabled ) {
-        await save_db_cached_geodata( ip, geoip_data )
-        cache( cache_key, geoip_data, GEODATA_CACHE_EXPIRY_MS )
-    } else {
-        cache( cache_key, geoip_data, 5 * 60 * 1000 )
-    }
 
-    return geoip_data
+    // --- Persist and cache the result ---
+    // MaxMind results get full DB persistence and 30-day TTL.
+    // geoip-lite as primary source (no MaxMind configured) also gets full persistence.
+    // Fallback results (validators, geoip-lite when MaxMind failed) get a short 5-minute
+    // in-memory TTL so MaxMind is retried after recovery.
+    const is_authoritative = !!maxmind_extras || !maxmind_insights_enabled
+    const ttl = is_authoritative ? GEODATA_CACHE_EXPIRY_MS : 5 * 60 * 1000
+
+    if( is_authoritative ) await save_db_cached_geodata( ip, geodata, maxmind_extras )
+    cache( cache_key, geodata, ttl )
+
+    return geodata
 
 }
 

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "tpn-node",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
+        "@maxmind/geoip2-node": "^6.3.4",
         "async-mutex": "^0.5.0",
         "cors": "^2.8.6",
         "express": "^5.2.1",
@@ -37,6 +38,7 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -52,6 +54,7 @@
       "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -94,6 +97,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -104,6 +108,7 @@
       "integrity": "sha512-Aa+yDiH87980jR6zvRfFuCR1+dLb00vBydhTL+zI992Rz/wQhSvuxjmOOuJOgO3XmakO6RykRGD2S1mq1AtgHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
@@ -123,6 +128,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -133,6 +139,7 @@
       "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.3",
         "@babel/types": "^7.28.2",
@@ -150,6 +157,7 @@
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.27.3"
       },
@@ -163,6 +171,7 @@
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -180,6 +189,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -190,6 +200,7 @@
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -200,6 +211,7 @@
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -214,6 +226,7 @@
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -232,6 +245,7 @@
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -242,6 +256,7 @@
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -252,6 +267,7 @@
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -262,6 +278,7 @@
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -272,6 +289,7 @@
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -286,6 +304,7 @@
       "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.4"
       },
@@ -302,6 +321,7 @@
       "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -318,6 +338,7 @@
       "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -334,6 +355,7 @@
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -354,6 +376,7 @@
       "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.27.1"
       },
@@ -370,6 +393,7 @@
       "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -409,6 +433,7 @@
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -424,6 +449,7 @@
       "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -443,6 +469,7 @@
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1"
@@ -457,6 +484,7 @@
       "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -476,6 +504,7 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -489,6 +518,7 @@
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -499,6 +529,7 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -523,6 +554,7 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -600,6 +632,7 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -615,6 +648,7 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -629,7 +663,8 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -637,6 +672,7 @@
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -648,6 +684,7 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -659,6 +696,7 @@
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -668,7 +706,8 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -676,9 +715,19 @@
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@maxmind/geoip2-node": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@maxmind/geoip2-node/-/geoip2-node-6.3.4.tgz",
+      "integrity": "sha512-BTRFHCX7Uie4wVSPXsWQfg0EVl4eGZgLCts0BTKAP+Eiyt1zmF2UPyuUZkaj0R59XSDYO+84o1THAtaenUoQYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "maxmind": "^5.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -687,6 +736,7 @@
       "integrity": "sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-scope": "5.1.1"
       }
@@ -697,6 +747,7 @@
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -711,6 +762,7 @@
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -721,6 +773,7 @@
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -755,7 +808,8 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -790,6 +844,7 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -815,6 +870,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -832,6 +888,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -877,7 +934,8 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -925,6 +983,7 @@
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1006,6 +1065,7 @@
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -1114,6 +1174,7 @@
       "integrity": "sha512-vAPMQdnyKCBtkmQA6FMCBvU9qFIppS3nzyXnEM+Lo2IAhG4Mpjv9cCxMudhgV3YdNNJv6TNqXy97dfRVL2LmaQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -1307,6 +1368,7 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1330,7 +1392,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1459,7 +1522,8 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1605,7 +1669,8 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -1668,6 +1733,7 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -1716,7 +1782,8 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.230.tgz",
       "integrity": "sha512-A6A6Fd3+gMdaed9wX83CvHYJb4UuapPD5X5SLq72VZJzxHSY0/LUweGXRWmQlh2ln7KV7iw7jnwXK7dlPoOnHQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -1731,7 +1798,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -1826,6 +1894,7 @@
       "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -1913,6 +1982,7 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1929,6 +1999,7 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2117,6 +2188,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -2150,6 +2222,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -2163,6 +2236,7 @@
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -2181,6 +2255,7 @@
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2214,6 +2289,7 @@
       "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -2224,6 +2300,7 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -2238,6 +2315,7 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2248,6 +2326,7 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2258,6 +2337,7 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2275,6 +2355,7 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2288,6 +2369,7 @@
       "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -2306,6 +2388,7 @@
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2319,6 +2402,7 @@
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2332,6 +2416,7 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2345,6 +2430,7 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2456,21 +2542,24 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -2478,6 +2567,7 @@
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2497,6 +2587,7 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -2540,6 +2631,7 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2557,6 +2649,7 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -2571,7 +2664,8 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -2766,6 +2860,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2896,6 +2991,7 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2909,6 +3005,7 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2959,7 +3056,8 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3099,7 +3197,6 @@
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "husky": "bin.js"
       },
@@ -3128,6 +3225,7 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -3145,6 +3243,7 @@
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3162,6 +3261,7 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -3496,6 +3596,7 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3684,6 +3785,7 @@
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-object-atoms": "^1.0.0",
@@ -3720,7 +3822,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3728,6 +3831,7 @@
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3747,6 +3851,7 @@
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3759,21 +3864,24 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -3781,6 +3889,7 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3811,6 +3920,7 @@
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -3827,6 +3937,7 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3856,6 +3967,7 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3870,6 +3982,7 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -3915,7 +4028,8 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3923,6 +4037,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3936,6 +4051,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -3953,6 +4069,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/maxmind": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.6.tgz",
+      "integrity": "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew==",
+      "license": "MIT",
+      "dependencies": {
+        "mmdb-lib": "3.0.2",
+        "tiny-lru": "13.0.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/media-typer": {
@@ -4032,7 +4162,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -4056,6 +4187,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mmdb-lib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+      "integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4067,7 +4208,8 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -4098,7 +4240,8 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
       "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nodemon": {
       "version": "3.1.11",
@@ -4233,6 +4376,7 @@
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -4339,6 +4483,7 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4375,6 +4520,7 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4391,6 +4537,7 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4407,6 +4554,7 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4429,6 +4577,7 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4493,7 +4642,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -4592,7 +4740,8 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4662,6 +4811,7 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4699,6 +4849,7 @@
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4754,6 +4905,7 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4792,7 +4944,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -4839,7 +4992,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -4952,6 +5106,7 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4961,6 +5116,7 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4971,6 +5127,7 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4983,6 +5140,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5029,6 +5187,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -5459,6 +5618,7 @@
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -5487,6 +5647,7 @@
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -5557,6 +5718,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5590,6 +5752,7 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -5627,7 +5790,8 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -5635,6 +5799,15 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -5706,6 +5879,7 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -5719,6 +5893,7 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5895,6 +6070,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -5912,6 +6088,7 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -6075,6 +6252,7 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6099,7 +6277,8 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
@@ -6117,6 +6296,7 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@fast-csv/format": "^5.0.5",
+    "@maxmind/geoip2-node": "^6.3.4",
     "async-mutex": "^0.5.0",
     "cors": "^2.8.6",
     "express": "^5.2.1",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/routes/validator/broadcast.js
+++ b/federated-container/routes/validator/broadcast.js
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { cache, log, make_retryable, sanetise_ipv4, sanetise_string } from 'mentie'
+import { log, make_retryable, sanetise_ipv4, sanetise_string } from 'mentie'
 import { cooldown_in_s, retry_times } from "../../modules/networking/routing.js"
 import { annotate_worker_with_defaults, is_valid_worker } from '../../modules/validations.js'
 import { find_clashing_workers, write_workers } from '../../modules/database/workers.js'
@@ -8,7 +8,7 @@ import { is_validator_request } from '../../modules/networking/validators.js'
 import { write_mining_pool_metadata } from '../../modules/database/mining_pools.js'
 import { map_ips_to_geodata } from '../../modules/geolocation/ip_mapping.js'
 import { resolve_domain_to_ip } from '../../modules/networking/network.js'
-import { ip_geodata, get_db_cached_geodata } from '../../modules/geolocation/helpers.js'
+import { ip_geodata } from '../../modules/geolocation/helpers.js'
 import { find_first_valid_workers_by_ip } from '../../modules/scoring/score_workers.js'
 const { CI_MODE } = process.env
 
@@ -191,8 +191,8 @@ router.post( '/mining_pool', async ( req, res ) => {
 
 
 /**
- * Serve cached geodata to peer validators.
- * Only returns data already in cache (in-memory or DB) — never triggers fresh resolution.
+ * Serve geodata to peer validators.
+ * Uses layers 1-3 only (cache + DB + MaxMind) to avoid recursive validator calls.
  */
 router.get( '/geodata/:ip', async ( req, res ) => {
 
@@ -201,17 +201,10 @@ router.get( '/geodata/:ip', async ( req, res ) => {
     if( !validator?.uid ) return res.status( 403 ).json( { error: `Requester not a known validator` } )
 
     const { ip } = req.params
+    const data = await ip_geodata( ip, { authoritative_only: true } )
 
-    // Check in-memory cache first
-    const cached_value = cache( `geoip:${ ip }` )
-    if( cached_value ) return res.json( { success: true, data: cached_value } )
-
-    // Check database cache
-    const db_cached = await get_db_cached_geodata( ip )
-    if( db_cached ) return res.json( { success: true, data: db_cached } )
-
-    // No cached data available
-    return res.status( 404 ).json( { success: false, error: `No cached geodata for this IP` } )
+    if( data ) return res.json( { success: true, data } )
+    return res.status( 404 ).json( { success: false, error: `No geodata available for this IP` } )
 
 } )
 

--- a/federated-container/routes/validator/broadcast.js
+++ b/federated-container/routes/validator/broadcast.js
@@ -15,6 +15,19 @@ const { CI_MODE } = process.env
 export const router = Router()
 
 /**
+ * Returns true when the payload looks like a worker object.
+ * @param {unknown} worker - Worker payload from the miner.
+ * @returns {boolean} Whether the payload is an object-like worker entry.
+ */
+const is_worker_object = worker => {
+
+    if( !worker || typeof worker !== `object` ) return false
+    if( Array.isArray( worker ) ) return false
+    return true
+
+}
+
+/**
  * Sanitises a worker IP without rejecting the full worker object.
  * Invalid or missing IPs are left untouched so later validation can drop them.
  * @param {Object} worker - Worker payload from the miner.
@@ -53,13 +66,16 @@ router.post( '/workers', async ( req, res ) => {
         if( !Array.isArray( workers ) ) throw new Error( `Invalid workers format, must be an array` )
         log.info( `Received ${ workers.length } workers from mining pool ${ mining_pool_uid }@${ mining_pool_ip }, example: `, workers[0] )
 
+        // Drop malformed entries before any property access or network lookups
+        const worker_objects = workers.filter( is_worker_object )
+        const dropped_worker_count = workers.length - worker_objects.length
+        if( dropped_worker_count ) log.warn( `Dropping ${ dropped_worker_count } non-object worker entries before preprocessing` )
+
         // Normalise IPs before any geodata or peer-validator lookups use miner-supplied values
-        workers = workers.map( sanitise_worker_ip )
+        workers = worker_objects.map( sanitise_worker_ip )
 
         // Check that the claimed countries and datacenter status are valid according to our db
         const workers_geo = await Promise.all( workers.map( async worker => {
-
-            if( !worker || typeof worker !== `object` ) return null
 
             const sanitised_ip = sanetise_ipv4( { ip: worker.ip, validate: true, error_on_invalid: false } )
             if( !sanitised_ip ) return null
@@ -70,7 +86,10 @@ router.post( '/workers', async ( req, res ) => {
         } ) )
 
         // Filter out workers where the mining_pool_url ip does not match the mining_pool_ip
-        const pool_urls_to_check = [ ...new Set( workers.map( worker => worker.mining_pool_url ) ) ]
+        const pool_urls_to_check = [ ...new Set( workers
+            .map( worker => worker.mining_pool_url )
+            .filter( url => typeof url === `string` && url.length )
+        ) ]
         const pool_url_ip_map = {}
         await Promise.all( pool_urls_to_check.map( async ( url ) => {
             try {

--- a/federated-container/routes/validator/broadcast.js
+++ b/federated-container/routes/validator/broadcast.js
@@ -196,15 +196,27 @@ router.post( '/mining_pool', async ( req, res ) => {
  */
 router.get( '/geodata/:ip', async ( req, res ) => {
 
-    // This endpoint is only for validators
-    const validator = await is_validator_request( req )
-    if( !validator?.uid ) return res.status( 403 ).json( { error: `Requester not a known validator` } )
+    try {
 
-    const { ip } = req.params
-    const data = await ip_geodata( ip, { authoritative_only: true } )
+        // This endpoint is only for validators
+        const validator = await is_validator_request( req )
+        if( !validator?.uid ) return res.status( 403 ).json( { error: `Requester not a known validator` } )
 
-    if( data ) return res.json( { success: true, data } )
-    return res.status( 404 ).json( { success: false, error: `No geodata available for this IP` } )
+        // Sanetise and validate the IP parameter
+        const sanitised_ip = sanetise_ipv4( { ip: req.params.ip, validate: true } )
+        if( !sanitised_ip ) return res.status( 400 ).json( { error: `Invalid IP address` } )
+
+        const data = await ip_geodata( sanitised_ip, { authoritative_only: true } )
+
+        if( data ) return res.json( { success: true, data } )
+        return res.status( 404 ).json( { success: false, error: `No geodata available for this IP` } )
+
+    } catch ( e ) {
+
+        log.warn( `Error handling geodata request for ${ req.params?.ip }:`, e )
+        return res.status( 400 ).json( { error: e.message } )
+
+    }
 
 } )
 

--- a/federated-container/routes/validator/broadcast.js
+++ b/federated-container/routes/validator/broadcast.js
@@ -1,13 +1,14 @@
 import { Router } from 'express'
-import { log, make_retryable, sanetise_ipv4, sanetise_string } from 'mentie'
+import { cache, log, make_retryable, sanetise_ipv4, sanetise_string } from 'mentie'
 import { cooldown_in_s, retry_times } from "../../modules/networking/routing.js"
 import { annotate_worker_with_defaults, is_valid_worker } from '../../modules/validations.js'
 import { find_clashing_workers, write_workers } from '../../modules/database/workers.js'
 import { is_miner_request } from '../../modules/networking/miners.js'
+import { is_validator_request } from '../../modules/networking/validators.js'
 import { write_mining_pool_metadata } from '../../modules/database/mining_pools.js'
 import { map_ips_to_geodata } from '../../modules/geolocation/ip_mapping.js'
 import { resolve_domain_to_ip } from '../../modules/networking/network.js'
-import { ip_geodata } from '../../modules/geolocation/helpers.js'
+import { ip_geodata, get_db_cached_geodata } from '../../modules/geolocation/helpers.js'
 import { find_first_valid_workers_by_ip } from '../../modules/scoring/score_workers.js'
 const { CI_MODE } = process.env
 
@@ -186,5 +187,31 @@ router.post( '/mining_pool', async ( req, res ) => {
         log.warn( `Error handling mining_pool broadcast. Error:`, e )
         return res.status( 200 ).json( { error: e.message } )
     }
+} )
+
+
+/**
+ * Serve cached geodata to peer validators.
+ * Only returns data already in cache (in-memory or DB) — never triggers fresh resolution.
+ */
+router.get( '/geodata/:ip', async ( req, res ) => {
+
+    // This endpoint is only for validators
+    const validator = await is_validator_request( req )
+    if( !validator?.uid ) return res.status( 403 ).json( { error: `Requester not a known validator` } )
+
+    const { ip } = req.params
+
+    // Check in-memory cache first
+    const cached_value = cache( `geoip:${ ip }` )
+    if( cached_value ) return res.json( { success: true, data: cached_value } )
+
+    // Check database cache
+    const db_cached = await get_db_cached_geodata( ip )
+    if( db_cached ) return res.json( { success: true, data: db_cached } )
+
+    // No cached data available
+    return res.status( 404 ).json( { success: false, error: `No cached geodata for this IP` } )
+
 } )
 

--- a/federated-container/routes/validator/broadcast.js
+++ b/federated-container/routes/validator/broadcast.js
@@ -15,6 +15,26 @@ const { CI_MODE } = process.env
 export const router = Router()
 
 /**
+ * Sanitises a worker IP without rejecting the full worker object.
+ * Invalid or missing IPs are left untouched so later validation can drop them.
+ * @param {Object} worker - Worker payload from the miner.
+ * @returns {Object} Worker with a normalised IP when valid.
+ */
+const sanitise_worker_ip = worker => {
+
+    if( !worker || typeof worker !== `object` ) return worker
+
+    try {
+        const sanitised_ip = sanetise_ipv4( { ip: worker.ip, validate: true, error_on_invalid: false } )
+        if( !sanitised_ip ) return worker
+        return { ...worker, ip: sanitised_ip }
+    } catch {
+        return worker
+    }
+
+}
+
+/**
  * Handle the submission of worker lists from mining pools
  * @params {Object} req.body.workers - Array of worker objects with properties: ip, country_code
  */
@@ -33,10 +53,20 @@ router.post( '/workers', async ( req, res ) => {
         if( !Array.isArray( workers ) ) throw new Error( `Invalid workers format, must be an array` )
         log.info( `Received ${ workers.length } workers from mining pool ${ mining_pool_uid }@${ mining_pool_ip }, example: `, workers[0] )
 
+        // Normalise IPs before any geodata or peer-validator lookups use miner-supplied values
+        workers = workers.map( sanitise_worker_ip )
+
         // Check that the claimed countries and datacenter status are valid according to our db
-        const workers_geo = await Promise.all( workers.map( async ( { ip } ) => {
-            const { country_code, connection_type, datacenter } = await ip_geodata( ip )
-            return { ip, country_code, connection_type, datacenter }
+        const workers_geo = await Promise.all( workers.map( async worker => {
+
+            if( !worker || typeof worker !== `object` ) return null
+
+            const sanitised_ip = sanetise_ipv4( { ip: worker.ip, validate: true, error_on_invalid: false } )
+            if( !sanitised_ip ) return null
+
+            const { country_code, connection_type, datacenter } = await ip_geodata( sanitised_ip )
+            return { ip: sanitised_ip, country_code, connection_type, datacenter }
+
         } ) )
 
         // Filter out workers where the mining_pool_url ip does not match the mining_pool_ip
@@ -66,7 +96,7 @@ router.post( '/workers', async ( req, res ) => {
         workers = workers.map( ( worker ) => {
 
             // Check is claimed data matches ours
-            const geo = workers_geo.find( g => g.ip === worker.ip )
+            const geo = workers_geo.find( g => g?.ip === worker?.ip )
             if( !geo ) return worker
             const country_matches = worker.country_code == geo.country_code
             const connection_type_matches = worker.connection_type == geo.connection_type
@@ -219,4 +249,3 @@ router.get( '/geodata/:ip', async ( req, res ) => {
     }
 
 } )
-


### PR DESCRIPTION
- Use MaxMind WebServiceClient insights when MAXMIND_ACCOUNT_ID and MAXMIND_LICENSE_KEY env vars are set
- Multi-layer caching: in-memory → postgres (ip_geodata_cache table) → API
- Store extra traits (userType, connectionType, userCount) in db cache
- 30-day configurable cache expiry for both in-memory and db layers
- Graceful fallback to geoip-lite + ip2location on API errors
- Non-MaxMind path also gains postgres cache layer