### PR TITLE
✨ expose X-Entry-Ip / X-Exit-Ip on lease responses

### DIFF
--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.8.0] - 2026-04-15
+
+### Added
+- `X-Entry-Ip` and `X-Exit-Ip` response headers on `/api/lease/new` (and `/api/config/new`) exposing the worker's dial-in and apparent-egress addresses — propagated end-to-end through worker → mining pool → validator
+- wireguard text configs now include `# Entry ip:` and `# Exit ip:` comment lines so clients can see both addresses at a glance
+- json lease responses include `entry_ip` and `exit_ip` alongside existing metadata
+
+### Changed
+- hardened `parse_wireguard_config` consumers in `modules/api/worker.js`: throw when the parser returns null instead of wrapping a "null" string/empty object as a truthy config
+
 ## [1.7.0] - 2026-04-15
 
 ### Added

--- a/federated-container/modules/api/mining_pool.js
+++ b/federated-container/modules/api/mining_pool.js
@@ -1,4 +1,4 @@
-import { abort_controller, cache, is_ipv4, log, shuffle_array } from "mentie"
+import { abort_controller, cache, is_ipv4, log, sanetise_ipv4, shuffle_array } from "mentie"
 import { v4 as uuidv4 } from 'uuid'
 import { get_config_directly_from_worker } from "../networking/worker.js"
 import { get_validators } from "../networking/validators.js"
@@ -104,10 +104,12 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
     const winning_worker = config?.worker ?? null
     const worker_result = config?.winner_nonce ? config.config : config
 
-    // Unwrap the worker result — get_config_directly_from_worker returns { config, lease_ref, lease_expires_at }
+    // Unwrap the worker result — get_config_directly_from_worker returns { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
     const resolved_config = worker_result?.config ?? worker_result
     const resolved_lease_ref = worker_result?.lease_ref ?? null
     const resolved_lease_expires_at = worker_result?.lease_expires_at ?? null
+    const resolved_entry_ip = sanetise_ipv4( { ip: worker_result?.entry_ip ?? winning_worker?.ip, validate: true, error_on_invalid: false } ) || null
+    const resolved_exit_ip = sanetise_ipv4( { ip: worker_result?.exit_ip ?? winning_worker?.ip, validate: true, error_on_invalid: false } ) || null
 
     // Mark request complete with winner so losing workers can free their configs
     if( resolved_config ) {
@@ -123,6 +125,8 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
         country: null,
         lease_ref: null,
         lease_expires_at: null,
+        entry_ip: null,
+        exit_ip: null,
     }
 
     // Return config wrapped with resolved worker metadata (available for all formats)
@@ -134,6 +138,8 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
         country: winning_worker?.country_code ?? null,
         lease_ref: resolved_lease_ref,
         lease_expires_at: resolved_lease_expires_at,
+        entry_ip: resolved_entry_ip,
+        exit_ip: resolved_exit_ip,
     }
 
 }

--- a/federated-container/modules/api/validator.js
+++ b/federated-container/modules/api/validator.js
@@ -1,4 +1,4 @@
-import { cache, is_ipv4, log, shuffle_array } from "mentie"
+import { cache, is_ipv4, log, sanetise_ipv4, shuffle_array } from "mentie"
 import { get_workers } from "../database/workers.js"
 import { get_worker_config_through_mining_pool } from "../networking/miners.js"
 import { resolve_domain_to_ip } from "../networking/network.js"
@@ -165,6 +165,11 @@ export async function get_worker_config_as_validator( { geo, type='wireguard', f
         } )
     }
 
+    // Entry/exit IPs come from the mining pool response; fall back to the worker
+    // record's single IP when upstream did not provide them (older pools, mocks).
+    const entry_ip = sanetise_ipv4( { ip: pool_result?.entry_ip ?? winning_worker?.ip, validate: true, error_on_invalid: false } ) || null
+    const exit_ip = sanetise_ipv4( { ip: pool_result?.exit_ip ?? winning_worker?.ip, validate: true, error_on_invalid: false } ) || null
+
     return {
         _lease_result: true,
         config: resolved_config,
@@ -173,6 +178,8 @@ export async function get_worker_config_as_validator( { geo, type='wireguard', f
         lease_token: signed_token,
         lease_ref,
         lease_expires_at,
+        entry_ip,
+        exit_ip,
     }
 
 
@@ -237,6 +244,8 @@ async function extend_lease_as_validator( { lease_token, lease_seconds, format='
         lease_token: new_token,
         lease_ref: pool_result.lease_ref ?? config_ref,
         lease_expires_at: new_expires_at,
+        entry_ip: sanetise_ipv4( { ip: pool_result.entry_ip ?? worker_ip, validate: true, error_on_invalid: false } ) || null,
+        exit_ip: sanetise_ipv4( { ip: pool_result.exit_ip ?? worker_ip, validate: true, error_on_invalid: false } ) || null,
     }
 
 }

--- a/federated-container/modules/api/worker.js
+++ b/federated-container/modules/api/worker.js
@@ -1,4 +1,4 @@
-import { abort_controller, log } from "mentie"
+import { abort_controller, log, sanetise_ipv4 } from "mentie"
 import { get_valid_wireguard_config, monitor_lease_ownership, read_wireguard_peer_config } from "../networking/wg-container.js"
 import { parse_wireguard_config } from "../networking/wireguard.js"
 import { MINING_POOL_URL } from "../networking/worker.js"
@@ -27,6 +27,18 @@ export async function get_worker_config_as_worker( { type='wireguard', lease_sec
     let lease_ref = null
     let lease_expires_at = null
 
+    // Entry (where the client dials) and exit (where traffic appears to egress) IPs.
+    // Currently both resolve to the worker's single public host — separate plumbing is
+    // kept in place so future deployments with distinct dial-in vs egress addresses
+    // can populate these independently without touching every caller.
+    const { SERVER_PUBLIC_HOST } = process.env
+    const entry_ip = sanetise_ipv4( { ip: SERVER_PUBLIC_HOST, validate: true, error_on_invalid: false } )
+    const exit_ip = sanetise_ipv4( { ip: SERVER_PUBLIC_HOST, validate: true, error_on_invalid: false } )
+
+    // Comment lines appended to wireguard text configs so clients can see both
+    // the address they dialled and the address their traffic will appear from.
+    const wireguard_ip_comments = `\n# Entry ip: ${ entry_ip } (you will connect to this)\n# Exit ip: ${ exit_ip } (you will appear to come from here)`
+
     // Extract trace from feedback URL for log correlation across hops
     let log_tag = ``
     if( feedback_url ) {
@@ -54,7 +66,8 @@ export async function get_worker_config_as_worker( { type='wireguard', lease_sec
             // Re-read the peer config from disk
             const wireguard_config = await read_wireguard_peer_config( { peer_id } )
             const { json_config, text_config } = parse_wireguard_config( { wireguard_config } )
-            config = format === `text` ? text_config : json_config
+            if( !text_config || !json_config ) throw new Error( `Extended WireGuard peer${ peer_id } config failed to parse` )
+            config = format === `text` ? `${ text_config }${ wireguard_ip_comments }` : { ...json_config, entry_ip, exit_ip }
             lease_ref = peer_id
             lease_expires_at = result.expires_at
 
@@ -77,7 +90,7 @@ export async function get_worker_config_as_worker( { type='wireguard', lease_sec
         }
 
         log.info( `${ log_tag }Lease extension complete for ${ type } ref=${ lease_ref }, new expires_at=${ new Date( lease_expires_at ).toISOString() }` )
-        return { config, lease_ref, lease_expires_at }
+        return { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
 
     }
 
@@ -96,8 +109,9 @@ export async function get_worker_config_as_worker( { type='wireguard', lease_sec
 
         // Return right format
         const { json_config, text_config } = parse_wireguard_config( { wireguard_config } )
-        if( format == 'text' ) config = text_config
-        else config = json_config
+        if( !text_config || !json_config ) throw new Error( `WireGuard peer${ peer_id } config failed to parse` )
+        if( format == 'text' ) config = `${ text_config }${ wireguard_ip_comments }`
+        else config = { ...json_config, entry_ip, exit_ip }
 
         lease_ref = peer_id
         lease_expires_at = expires_at
@@ -125,7 +139,7 @@ export async function get_worker_config_as_worker( { type='wireguard', lease_sec
         lease_expires_at = expires_at
     }
 
-    return { config, lease_ref, lease_expires_at }
+    return { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
 
 }
 

--- a/federated-container/modules/networking/miners.js
+++ b/federated-container/modules/networking/miners.js
@@ -1,4 +1,4 @@
-import { abort_controller, is_ipv4, log, wait } from "mentie"
+import { abort_controller, is_ipv4, log, sanetise_ipv4, wait } from "mentie"
 import { ip_from_req } from "./network.js"
 import { get_tpn_cache } from "../caching.js"
 import { read_mining_pool_metadata } from "../database/mining_pools.js"
@@ -135,13 +135,15 @@ export async function get_worker_config_through_mining_pool( { worker, max_retri
     if( CI_MOCK_MINING_POOL_RESPONSES === 'true' ) {
         log.info( `CI_MOCK_MINING_POOL_RESPONSES is enabled, returning mock response for ${ endpoint }/${ query }` )
         const mock_config = format === 'json' ? { json_config: { endpoint_ipv4: 'mock.mock.mock.mock' }, text_config: "" } : "Mock WireGuard config"
-        return { config: mock_config, lease_ref: null, lease_expires_at: null }
+        return { config: mock_config, lease_ref: null, lease_expires_at: null, entry_ip: null, exit_ip: null }
     }
 
     // Get config through mining pool, reading lease metadata headers alongside the body
     let config = null
     let lease_ref = null
     let lease_expires_at = null
+    let entry_ip = null
+    let exit_ip = null
     let attempts = 0
     while( !config && attempts < max_retries ) {
 
@@ -155,8 +157,10 @@ export async function get_worker_config_through_mining_pool( { worker, max_retri
             if( !res.ok ) throw new Error( `Mining pool ${ mining_pool_uid } returned HTTP ${ res.status }` )
             const ref = res.headers.get( `X-Lease-Ref` )
             const expires = res.headers.get( `X-Lease-Expires` )
+            const entry = res.headers.get( `X-Entry-Ip` )
+            const exit = res.headers.get( `X-Exit-Ip` )
             const body = format === `json` ? await res.json() : await res.text()
-            return { body, ref, expires }
+            return { body, ref, expires, entry, exit }
 
         } ).catch( e => {
             log.warn( `Error fetching worker config from mining pool ${ mining_pool_uid } on attempt ${ attempts }:`, e.message )
@@ -167,12 +171,14 @@ export async function get_worker_config_through_mining_pool( { worker, max_retri
             config = result.body
             lease_ref = result.ref || null
             lease_expires_at = result.expires ? Number( result.expires ) : null
+            entry_ip = result.entry ? sanetise_ipv4( { ip: result.entry, validate: true, error_on_invalid: false } ) : null
+            exit_ip = result.exit ? sanetise_ipv4( { ip: result.exit, validate: true, error_on_invalid: false } ) : null
             log.info( `Received config from mining pool ${ mining_pool_uid } for worker ${ worker.ip }` )
         }
 
     }
 
     if( !config ) return null
-    return { config, lease_ref, lease_expires_at }
+    return { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
 
 }

--- a/federated-container/modules/networking/worker.js
+++ b/federated-container/modules/networking/worker.js
@@ -1,4 +1,4 @@
-import { abort_controller, log, sanetise_string } from "mentie"
+import { abort_controller, log, sanetise_ipv4, sanetise_string } from "mentie"
 const { SERVER_PUBLIC_PORT=3000 } = process.env
 
 /**
@@ -60,6 +60,8 @@ export async function get_config_directly_from_worker( { worker, max_retries=2, 
     let config = null
     let lease_ref = null
     let lease_expires_at = null
+    let entry_ip = null
+    let exit_ip = null
     let attempts = 0
     while( !config && attempts < max_retries ) {
 
@@ -72,9 +74,11 @@ export async function get_config_directly_from_worker( { worker, max_retries=2, 
             // Read lease metadata headers before parsing body
             const ref = res.headers.get( `X-Lease-Ref` )
             const expires = res.headers.get( `X-Lease-Expires` )
+            const entry = res.headers.get( `X-Entry-Ip` )
+            const exit = res.headers.get( `X-Exit-Ip` )
             if( !res.ok ) throw new Error( `Worker ${ ip } returned HTTP ${ res.status }` )
             const body = format === `json` ? await res.json() : await res.text()
-            return { body, ref, expires }
+            return { body, ref, expires, entry, exit }
 
         } ).catch( e => {
             log.warn( `Error fetching config from worker ${ ip } on attempt ${ attempts }:`, e.message )
@@ -85,6 +89,8 @@ export async function get_config_directly_from_worker( { worker, max_retries=2, 
             config = result.body
             lease_ref = result.ref || null
             lease_expires_at = result.expires ? Number( result.expires ) : null
+            entry_ip = result.entry ? sanetise_ipv4( { ip: result.entry, validate: true, error_on_invalid: false } ) : null
+            exit_ip = result.exit ? sanetise_ipv4( { ip: result.exit, validate: true, error_on_invalid: false } ) : null
             log.info( `Received ${ type } config from worker ${ ip }` )
         }
 
@@ -96,5 +102,5 @@ export async function get_config_directly_from_worker( { worker, max_retries=2, 
     // On mock success
     if( CI_MOCK_WORKER_RESPONSES ) config = config || ( format === 'json' ? { endpoint_ipv4: 'mock.mock.mock.mock' } : "Mock WireGuard config" )
 
-    return { config, lease_ref, lease_expires_at }
+    return { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
 }

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/routes/api/lease.js
+++ b/federated-container/routes/api/lease.js
@@ -44,6 +44,8 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
         delete resolved_meta.lease_ref
         delete resolved_meta.lease_expires_at
         delete resolved_meta.lease_token
+        delete resolved_meta.entry_ip
+        delete resolved_meta.exit_ip
 
         // Mining pool access controls
         const { mode, worker_mode, miner_mode, validator_mode } = run_mode()
@@ -151,7 +153,7 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
         if( worker_mode ) result = await get_worker_config_as_worker( config_meta )
 
         // Unwrap lease result — mining pool and validator return { _lease_result, config, ... }
-        // Worker now returns { config, lease_ref, lease_expires_at } directly
+        // Worker now returns { config, lease_ref, lease_expires_at, entry_ip, exit_ip } directly
         let config = result
         if( result?._lease_result ) {
             if( result.connection_type ) resolved_meta.connection_type = result.connection_type
@@ -159,11 +161,15 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
             if( result.lease_ref != null ) resolved_meta.lease_ref = result.lease_ref
             if( result.lease_expires_at != null ) resolved_meta.lease_expires_at = result.lease_expires_at
             if( result.lease_token ) resolved_meta.lease_token = result.lease_token
+            if( result.entry_ip ) resolved_meta.entry_ip = result.entry_ip
+            if( result.exit_ip ) resolved_meta.exit_ip = result.exit_ip
             config = result.config
         } else if( result?.lease_ref !== undefined ) {
-            // Worker-mode result: { config, lease_ref, lease_expires_at }
+            // Worker-mode result: { config, lease_ref, lease_expires_at, entry_ip, exit_ip }
             if( result.lease_ref != null ) resolved_meta.lease_ref = result.lease_ref
             if( result.lease_expires_at != null ) resolved_meta.lease_expires_at = result.lease_expires_at
+            if( result.entry_ip ) resolved_meta.entry_ip = result.entry_ip
+            if( result.exit_ip ) resolved_meta.exit_ip = result.exit_ip
             config = result.config
         }
 
@@ -172,6 +178,8 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
             if( resolved_meta.connection_type && !config.connection_type ) config.connection_type = resolved_meta.connection_type
             if( resolved_meta.country && !config.country ) config.country = resolved_meta.country
             if( resolved_meta.lease_token ) config.lease_token = resolved_meta.lease_token
+            if( resolved_meta.entry_ip && !config.entry_ip ) config.entry_ip = resolved_meta.entry_ip
+            if( resolved_meta.exit_ip && !config.exit_ip ) config.exit_ip = resolved_meta.exit_ip
         }
 
         // Validate config
@@ -197,6 +205,8 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
         if( resolved_meta.lease_ref ) res.set( 'X-Lease-Ref', `${ resolved_meta.lease_ref }` )
         if( resolved_meta.lease_expires_at ) res.set( 'X-Lease-Expires', `${ resolved_meta.lease_expires_at }` )
         if( resolved_meta.lease_token ) res.set( 'X-Lease-Extension-Token', resolved_meta.lease_token )
+        if( resolved_meta.entry_ip ) res.set( 'X-Entry-Ip', resolved_meta.entry_ip )
+        if( resolved_meta.exit_ip ) res.set( 'X-Exit-Ip', resolved_meta.exit_ip )
 
         return format == 'text' ? res.send( response_data ) : res.json( response_data )
     } catch ( e ) {


### PR DESCRIPTION
Propagates entry (dial-in) and exit (apparent-egress) IPs end-to-end through worker → mining pool → validator. Adds matching X-Entry-Ip / X-Exit-Ip response headers, entry_ip / exit_ip fields on JSON lease bodies, and # Entry ip: / # Exit ip: comment lines on wireguard text configs. All IP values pass through sanetise_ipv4. Today the values collapse to the worker's single public IP; the plumbing lets future deployments carry distinct ingress vs egress addresses without touching every caller.

Also hardens parse_wireguard_config consumers to throw on null parse results instead of wrapping them into truthy but broken configs.