### PR TITLE
✨ expose entry/exit ip on lease responses

### DIFF
--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.8.0] - 2026-04-15
+
+### Added
+- expose `X-Entry-Ip` and `X-Exit-Ip` response headers on lease requests
+- annotate WireGuard text configs with trailing `# Entry ip:` / `# Exit ip:` comment lines
+
 ## [1.7.0] - 2026-04-15
 
 ### Added

--- a/federated-container/modules/api/mining_pool.js
+++ b/federated-container/modules/api/mining_pool.js
@@ -123,6 +123,7 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
         country: null,
         lease_ref: null,
         lease_expires_at: null,
+        exit_ip: null,
     }
 
     // Return config wrapped with resolved worker metadata (available for all formats)
@@ -134,6 +135,7 @@ export async function get_worker_config_as_miner( { geo, type='wireguard', forma
         country: winning_worker?.country_code ?? null,
         lease_ref: resolved_lease_ref,
         lease_expires_at: resolved_lease_expires_at,
+        exit_ip: winning_worker?.ip ?? null,
     }
 
 }

--- a/federated-container/modules/api/validator.js
+++ b/federated-container/modules/api/validator.js
@@ -173,6 +173,7 @@ export async function get_worker_config_as_validator( { geo, type='wireguard', f
         lease_token: signed_token,
         lease_ref,
         lease_expires_at,
+        exit_ip: winning_worker?.ip ?? null,
     }
 
 
@@ -237,6 +238,7 @@ async function extend_lease_as_validator( { lease_token, lease_seconds, format='
         lease_token: new_token,
         lease_ref: pool_result.lease_ref ?? config_ref,
         lease_expires_at: new_expires_at,
+        exit_ip: worker_ip,
     }
 
 }

--- a/federated-container/openapi.yaml
+++ b/federated-container/openapi.yaml
@@ -490,6 +490,10 @@ paths:
               schema:
                 type: string
               description: Lease expiration timestamp (Unix ms, string-encoded).
+            X-Lease-Extension-Token:
+              schema:
+                type: string
+              description: Opaque token that can be used to extend the lease. Present only when a lease token is issued (e.g. validator mode). Useful for `format=text` consumers that cannot read `lease_token` from the JSON body.
             X-Entry-Ip:
               schema:
                 type: string

--- a/federated-container/openapi.yaml
+++ b/federated-container/openapi.yaml
@@ -173,6 +173,14 @@ paths:
               schema:
                 type: string
               description: Opaque token that can be used to extend the lease. Present only when a lease token is issued (e.g. validator mode). Useful for `format=text` consumers that cannot read `lease_token` from the JSON body.
+            X-Entry-Ip:
+              schema:
+                type: string
+              description: The IP address the caller connects to (WireGuard `Endpoint` or SOCKS5 `ip_address`). Present when resolvable from the returned config.
+            X-Exit-Ip:
+              schema:
+                type: string
+              description: The IP address traffic appears to come from — the worker IP as registered with the validator. Present when the lease was resolved via validator/mining-pool routing.
           content:
             application/json:
               schema:
@@ -480,6 +488,14 @@ paths:
               schema:
                 type: string
               description: Lease expiration timestamp (Unix ms, string-encoded).
+            X-Entry-Ip:
+              schema:
+                type: string
+              description: The IP address the caller connects to (WireGuard `Endpoint` or SOCKS5 `ip_address`).
+            X-Exit-Ip:
+              schema:
+                type: string
+              description: The IP address traffic appears to come from — the worker IP as registered with the validator.
           content:
             application/json:
               schema:

--- a/federated-container/openapi.yaml
+++ b/federated-container/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: TPN Network Federated API
-  version: 1.3.3
+  version: 1.4.0
   description: |
     Public HTTP API exposed by the TPN Network federated container. The routes
     documented here are mounted under `/api` and cover live lease negotiation and
@@ -246,6 +246,8 @@ paths:
                     PresharedKey = EXAMPLE5sEDGxRoAkpzXibnCCLpSkhV3BNGIaH5XJDKiIG79OY=
                     AllowedIPs = 0.0.0.0/0
                     Endpoint = 203.0.113.54:51820
+                    # Entry ip: 203.0.113.54 (you will connect to this)
+                    # Exit ip: 198.51.100.17 (you will appear to come from here)
                 socks5Profile:
                   summary: SOCKS5 config as plain text
                   value: socks5://u_demo:p_secret@203.0.113.42:1080

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/routes/api/lease.js
+++ b/federated-container/routes/api/lease.js
@@ -27,6 +27,36 @@ const constant_time_includes = ( keys, candidate ) => {
     } )
 }
 
+/**
+ * Extracts the entry IP — the endpoint the caller will connect to — from a lease config.
+ * Handles both text and JSON representations of WireGuard and SOCKS5 configs.
+ * @param {Object} params
+ * @param {string|Object} params.config - The lease config (text form or parsed JSON)
+ * @param {string} params.type - The lease type ('wireguard' or 'socks5')
+ * @returns {string|null} The entry IP, or null if it could not be determined
+ */
+const extract_entry_ip = ( { config, type } ) => {
+
+    if( !config ) return null
+
+    // WireGuard: JSON has peer.Endpoint = "ip:port"; text has an "Endpoint = ip:port" line
+    if( type === 'wireguard' ) {
+        if( typeof config === 'object' ) return config.peer?.Endpoint?.split( ':' )[ 0 ] || null
+        const [ , endpoint_ip ] = `${ config }`.match( /Endpoint\s*=\s*([^:\s]+)/ ) || []
+        return endpoint_ip || null
+    }
+
+    // SOCKS5: JSON has ip_address; text is socks5://user:pass@ip:port
+    if( type === 'socks5' ) {
+        if( typeof config === 'object' ) return config.ip_address || null
+        const [ , endpoint_ip ] = `${ config }`.match( /@([^:\s]+):/ ) || []
+        return endpoint_ip || null
+    }
+
+    return null
+
+}
+
 export const router = Router()
 
 router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
@@ -44,6 +74,8 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
         delete resolved_meta.lease_ref
         delete resolved_meta.lease_expires_at
         delete resolved_meta.lease_token
+        delete resolved_meta.entry_ip
+        delete resolved_meta.exit_ip
 
         // Mining pool access controls
         const { mode, worker_mode, miner_mode, validator_mode } = run_mode()
@@ -159,12 +191,24 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
             if( result.lease_ref != null ) resolved_meta.lease_ref = result.lease_ref
             if( result.lease_expires_at != null ) resolved_meta.lease_expires_at = result.lease_expires_at
             if( result.lease_token ) resolved_meta.lease_token = result.lease_token
+            if( result.exit_ip ) resolved_meta.exit_ip = result.exit_ip
             config = result.config
         } else if( result?.lease_ref !== undefined ) {
             // Worker-mode result: { config, lease_ref, lease_expires_at }
             if( result.lease_ref != null ) resolved_meta.lease_ref = result.lease_ref
             if( result.lease_expires_at != null ) resolved_meta.lease_expires_at = result.lease_expires_at
             config = result.config
+        }
+
+        // Derive entry IP — the endpoint the caller connects to — from the returned config
+        resolved_meta.entry_ip = extract_entry_ip( { config, type } )
+
+        // Annotate wireguard text configs with the entry/exit IP pair at the bottom
+        // so downstream consumers can see the routing topology at a glance.
+        if( type === 'wireguard' && typeof config === 'string' ) {
+            const entry_ip = resolved_meta.entry_ip || 'unknown'
+            const exit_ip = resolved_meta.exit_ip || 'unknown'
+            config = `${ config }\n# Entry ip: ${ entry_ip } (you will connect to this)\n# Exit ip: ${ exit_ip } (you will appear to come from here)\n`
         }
 
         // Enrich JSON responses with resolved metadata in the body
@@ -197,6 +241,8 @@ router.get( [ '/config/new', '/lease/new' ], async ( req, res ) => {
         if( resolved_meta.lease_ref ) res.set( 'X-Lease-Ref', `${ resolved_meta.lease_ref }` )
         if( resolved_meta.lease_expires_at ) res.set( 'X-Lease-Expires', `${ resolved_meta.lease_expires_at }` )
         if( resolved_meta.lease_token ) res.set( 'X-Lease-Extension-Token', resolved_meta.lease_token )
+        if( resolved_meta.entry_ip ) res.set( 'X-Entry-Ip', resolved_meta.entry_ip )
+        if( resolved_meta.exit_ip ) res.set( 'X-Exit-Ip', resolved_meta.exit_ip )
 
         return format == 'text' ? res.send( response_data ) : res.json( response_data )
     } catch ( e ) {

--- a/federated-container/routes/api/lease.js
+++ b/federated-container/routes/api/lease.js
@@ -42,15 +42,17 @@ const extract_entry_ip = ( { config, type } ) => {
     // WireGuard: JSON has peer.Endpoint = "ip:port"; text has an "Endpoint = ip:port" line
     if( type === 'wireguard' ) {
         if( typeof config === 'object' ) return config.peer?.Endpoint?.split( ':' )[ 0 ] || null
-        const [ , endpoint_ip ] = `${ config }`.match( /Endpoint\s*=\s*([^:\s]+)/ ) || []
-        return endpoint_ip || null
+        let [ , ip ] = `${ config }`.match( /Endpoint\s*=\s*([^:\s]+)/ ) || []
+        ip = sanetise_ipv4( { ip, validate: true } )
+        return ip
     }
 
     // SOCKS5: JSON has ip_address; text is socks5://user:pass@ip:port
     if( type === 'socks5' ) {
         if( typeof config === 'object' ) return config.ip_address || null
-        const [ , endpoint_ip ] = `${ config }`.match( /@([^:\s]+):/ ) || []
-        return endpoint_ip || null
+        let [ , ip ] = `${ config }`.match( /@([^:\s]+):/ ) || []
+        ip = sanetise_ipv4( { ip, validate: true } )
+        return ip
     }
 
     return null


### PR DESCRIPTION
Add X-Entry-Ip and X-Exit-Ip headers to lease requests, and annotate wireguard text configs with # Entry ip / # Exit ip comment lines.

Bump to 1.8.0.