### PR TITLE
🔥 remove wandb integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ source venv/bin/activate
 TPN_CACHE="$HOME/.tpn_cache"
 mkdir -p $TPN_CACHE
 export TMPDIR=$TPN_CACHE
-export WANDB_CACHE_DIR=$TPN_CACHE
 pip3 install -r requirements.txt
 export PYTHONPATH=.
 ```
@@ -271,45 +270,7 @@ Here are some examples of how a minint pool could operate:
 
 Validators are the interface between end users and miners. They send work requests to miners, which the miners complete and submit to the validator. Running a validator is more complicated than a miner and requires more setup than a miner.
 
-### Step 1: Configure the validator settings
-
-The validator neuron needs you to supply a WanDB API key. You can get one by signing up at [WanDB](https://wandb.ai/site). Once you have the key, add it to your environment by running the code below:
-
-```bash
-# 🚨 Change the below to your API key
-WANDB_API_KEY=xxxx
-
-# Determine the default login shell using the SHELL env variable
-shell=$(basename "$SHELL")
-export_line="export WANDB_API_KEY=$WANDB_API_KEY"
-
-# For bash: if the default shell is bash, add the export_line to ~/.bashrc if not present
-if [[ "$shell" == "bash" ]]; then
-  # Check if the exact export_line exists in ~/.bashrc
-  if ! grep -Fxq "$export_line" ~/.bashrc; then
-    echo "$export_line" >> ~/.bashrc  # Append if not found
-    echo "Added '$export_line' to ~/.bashrc"
-  else
-    echo "'$export_line' already exists in ~/.bashrc"
-  fi
-fi
-
-# For zsh: if the default shell is zsh, add the export_line to ~/.zshrc if not present
-if [[ "$shell" == "zsh" ]]; then
-  # Check if the exact export_line exists in ~/.zshrc
-  if ! grep -Fxq "$export_line" ~/.zshrc; then
-    echo "$export_line" >> ~/.zshrc  # Append if not found
-    echo "Added '$export_line' to ~/.zshrc"
-  else
-    echo "'$export_line' already exists in ~/.zshrc"
-  fi
-fi
-
-# Run the export line in the current shell
-eval $export_line
-```
-
-### Step 2: Start the validator
+### Start the validator
 
 The validator also consists out of two components:
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -18,15 +18,12 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-import os
 import time
-import datetime
 import logging
 import requests
 
 # Bittensor
 import bittensor as bt
-import wandb
 
 # import base validator class which takes care of most of the boilerplate
 from sybil.base.validator import BaseValidatorNeuron
@@ -75,43 +72,6 @@ class Validator(BaseValidatorNeuron):
             pass
 
         bt.logging.info(f"===> Validator initialized: {self.step}, {len(self.scores)}, {len(self.hotkeys)}")
-
-        self.wandb_run_start = None
-        if not self.config.wandb.off:
-            if os.getenv("WANDB_API_KEY"):
-                self.new_wandb_run()
-            else:
-                bt.logging.exception(
-                    "WANDB_API_KEY not found. Set it with `export WANDB_API_KEY=<your API key>`. Alternatively, you can disable W&B with --wandb.off, but it is strongly recommended to run with W&B enabled."
-                )
-                self.config.wandb.off = True
-        else:
-            bt.logging.warning(
-                "Running with --wandb.off. It is strongly recommended to run with W&B enabled."
-            )
-
-    def new_wandb_run(self):
-        """Creates a new wandb run to save information to."""
-        # Create a unique run id for this run.
-        now = datetime.datetime.now()
-        self.wandb_run_start = now
-        run_id = now.strftime("%Y-%m-%d_%H-%M-%S")
-        name = "validator-" + str(self.uid) + "-" + run_id
-        self.wandb_run = wandb.init(
-            name=name,
-            project="tpn-validators",
-            entity="tpn-subnet",
-            config={
-                "uid": self.uid,
-                "hotkey": self.wallet.hotkey.ss58_address,
-                "run_name": run_id,
-                "type": "validator",
-            },
-            allow_val_change=True,
-            anonymous="allow",
-        )
-
-        bt.logging.debug(f"Started a new wandb run: {name}")
 
     async def forward(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ rich>=13
 pytest>=8
 numpy>=1
 setuptools>=68
-wandb==0.19.6
 bittensor-cli>=9.17.0

--- a/scripts/update_node.sh
+++ b/scripts/update_node.sh
@@ -454,7 +454,6 @@ if [ "$RUN_MODE" != "worker" ]; then
         TPN_CACHE="$HOME/.tpn_cache"
         mkdir -p "$TPN_CACHE"
         export TMPDIR=$TPN_CACHE
-        export WANDB_CACHE_DIR=$TPN_CACHE
 
         echo "Installing Python dependencies..."
         if ! pip install -r requirements.txt; then

--- a/sybil/utils/config.py
+++ b/sybil/utils/config.py
@@ -109,27 +109,6 @@ def add_args(cls, parser):
         default=False,
     )
 
-    parser.add_argument(
-        "--wandb.off",
-        action="store_true",
-        help="Turn off wandb.",
-        default=False,
-    )
-
-    parser.add_argument(
-        "--wandb.offline",
-        action="store_true",
-        help="Runs wandb in offline mode.",
-        default=False,
-    )
-
-    parser.add_argument(
-        "--wandb.notes",
-        type=str,
-        help="Notes to add to the wandb run.",
-        default="",
-    )
-
 
 def add_miner_args(cls, parser):
     """Add miner specific arguments to the parser."""
@@ -155,20 +134,6 @@ def add_miner_args(cls, parser):
         default=False,
     )
 
-    parser.add_argument(
-        "--wandb.project_name",
-        type=str,
-        default="sybil-miners",
-        help="Wandb project to log to.",
-    )
-
-    parser.add_argument(
-        "--wandb.entity",
-        type=str,
-        default="opentensor-dev",
-        help="Wandb entity to log to.",
-    )
-    
     parser.add_argument(
         "--miner.server",
         type=str,
@@ -237,20 +202,6 @@ def add_validator_args(cls, parser):
         type=int,
         help="The maximum number of TAO allowed to query a validator with a vpermit.",
         default=4096,
-    )
-
-    parser.add_argument(
-        "--wandb.project_name",
-        type=str,
-        help="The name of the project where you are sending the new run.",
-        default="sybil-validators",
-    )
-
-    parser.add_argument(
-        "--wandb.entity",
-        type=str,
-        help="The name of the project where you are sending the new run.",
-        default="opentensor-dev",
     )
 
     parser.add_argument(


### PR DESCRIPTION
The validator initialized a wandb run on startup but never logged any metrics, making the dependency, API key requirement, and CLI args inert. Strips imports, config args, requirements, cache env var, and setup docs.