### PR TITLE
Scale max pool worker validation logic, deprecate wandb, monotonic performance counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ source venv/bin/activate
 TPN_CACHE="$HOME/.tpn_cache"
 mkdir -p $TPN_CACHE
 export TMPDIR=$TPN_CACHE
-export WANDB_CACHE_DIR=$TPN_CACHE
 pip3 install -r requirements.txt
 export PYTHONPATH=.
 ```
@@ -271,45 +270,7 @@ Here are some examples of how a minint pool could operate:
 
 Validators are the interface between end users and miners. They send work requests to miners, which the miners complete and submit to the validator. Running a validator is more complicated than a miner and requires more setup than a miner.
 
-### Step 1: Configure the validator settings
-
-The validator neuron needs you to supply a WanDB API key. You can get one by signing up at [WanDB](https://wandb.ai/site). Once you have the key, add it to your environment by running the code below:
-
-```bash
-# 🚨 Change the below to your API key
-WANDB_API_KEY=xxxx
-
-# Determine the default login shell using the SHELL env variable
-shell=$(basename "$SHELL")
-export_line="export WANDB_API_KEY=$WANDB_API_KEY"
-
-# For bash: if the default shell is bash, add the export_line to ~/.bashrc if not present
-if [[ "$shell" == "bash" ]]; then
-  # Check if the exact export_line exists in ~/.bashrc
-  if ! grep -Fxq "$export_line" ~/.bashrc; then
-    echo "$export_line" >> ~/.bashrc  # Append if not found
-    echo "Added '$export_line' to ~/.bashrc"
-  else
-    echo "'$export_line' already exists in ~/.bashrc"
-  fi
-fi
-
-# For zsh: if the default shell is zsh, add the export_line to ~/.zshrc if not present
-if [[ "$shell" == "zsh" ]]; then
-  # Check if the exact export_line exists in ~/.zshrc
-  if ! grep -Fxq "$export_line" ~/.zshrc; then
-    echo "$export_line" >> ~/.zshrc  # Append if not found
-    echo "Added '$export_line' to ~/.zshrc"
-  else
-    echo "'$export_line' already exists in ~/.zshrc"
-  fi
-fi
-
-# Run the export line in the current shell
-eval $export_line
-```
-
-### Step 2: Start the validator
+### Start the validator
 
 The validator also consists out of two components:
 

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -3,15 +3,15 @@
 ## [1.10.0] - 2026-04-29
 
 ### Added
-- `concurrency` parameter on `validate_and_annotate_workers` (default 200) — caps parallel worker tests below the ~253-slot veth subnet pool so high worker counts no longer starve the network namespace allocator
+- `concurrency` parameter on `validate_and_annotate_workers` (default 200) — caps parallel worker tests below the 255-slot veth subnet pool so high worker counts no longer starve the network namespace allocator
 - `max_worker_test_time_s` parameter on `validate_and_annotate_workers` (default 60) — soft per-worker timeout that marks slow workers `down` while letting the underlying wireguard test finish its cleanup
 
 ### Fixed
 - wireguard cleanup now removes the MASQUERADE iptables rule using `${ uplink_interface }` instead of a hardcoded `eth0`, so hosts whose uplink is `ens5` / `enp0s*` / etc. no longer leak NAT rules
+- veth subnet selector in `network.js:mk_subnet_prefix` now correctly produces `{1..255}` via `random_number_between( 255 )`. The previous `random_number_between( 1, 254 )` form relied on mentie's reversed `(max_num, min_num=1)` signature and accidentally yielded `{2..254}` — same intent, but a maintenance trap for readers expecting `(min, max)`
 
 ### Changed
 - removed the obsolete `>250 workers` warning in `validate_and_annotate_workers` — superseded by the concurrency cap
-- documented the intentional `10.200.{2..254}` subnet pool range in `network.js:mk_subnet_prefix` (.1 host-side, .255 broadcast)
 
 ## [1.9.0] - 2026-04-20
 

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - wireguard cleanup now removes the MASQUERADE iptables rule using `${ uplink_interface }` instead of a hardcoded `eth0`, so hosts whose uplink is `ens5` / `enp0s*` / etc. no longer leak NAT rules
 - veth subnet selector in `network.js:mk_subnet_prefix` now correctly produces `{1..255}` via `random_number_between( 255 )`. The previous `random_number_between( 1, 254 )` form relied on mentie's reversed `(max_num, min_num=1)` signature and accidentally yielded `{2..254}` — same intent, but a maintenance trap for readers expecting `(min, max)`
+- concurrent worker validation now preserves input order in returned successes/failures/statuses, matching the previous `Promise.allSettled` behavior
 
 ### Changed
 - removed the obsolete `>250 workers` warning in `validate_and_annotate_workers` — superseded by the concurrency cap

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 - removed the obsolete `>250 workers` warning in `validate_and_annotate_workers` — superseded by the concurrency cap
+- validator audits are now globally exclusive, wait for active scoring validation to drain, and run worker validation at concurrency 100; scoring also drops to concurrency 100 while an audit is pending/active
 
 ## [1.9.0] - 2026-04-20
 

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.10.1] - 2026-05-04
+
+### Fixed
+- use monotonic timers to prevent negative scoring durations
+
 ## [1.10.0] - 2026-04-29
 
 ### Added

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.10.0] - 2026-04-29
+
+### Added
+- `concurrency` parameter on `validate_and_annotate_workers` (default 200) — caps parallel worker tests below the ~253-slot veth subnet pool so high worker counts no longer starve the network namespace allocator
+- `max_worker_test_time_s` parameter on `validate_and_annotate_workers` (default 60) — soft per-worker timeout that marks slow workers `down` while letting the underlying wireguard test finish its cleanup
+
+### Fixed
+- wireguard cleanup now removes the MASQUERADE iptables rule using `${ uplink_interface }` instead of a hardcoded `eth0`, so hosts whose uplink is `ens5` / `enp0s*` / etc. no longer leak NAT rules
+
+### Changed
+- removed the obsolete `>250 workers` warning in `validate_and_annotate_workers` — superseded by the concurrency cap
+- documented the intentional `10.200.{2..254}` subnet pool range in `network.js:mk_subnet_prefix` (.1 host-side, .255 broadcast)
+
 ## [1.9.0] - 2026-04-20
 
 ### Added

--- a/federated-container/CHANGELOG.md
+++ b/federated-container/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - `concurrency` parameter on `validate_and_annotate_workers` (default 200) — caps parallel worker tests below the 255-slot veth subnet pool so high worker counts no longer starve the network namespace allocator
-- `max_worker_test_time_s` parameter on `validate_and_annotate_workers` (default 60) — soft per-worker timeout that marks slow workers `down` while letting the underlying wireguard test finish its cleanup
+- `max_worker_test_time_s` parameter on `validate_and_annotate_workers` (default 60) — observability marker that flags worker tests exceeding this duration as `down` with a timeout error. The runner always awaits natural completion of the underlying wireguard test so the veth subnet slot is released before the next worker is picked up — cancelling the inner test would orphan its slot and silently violate the concurrency cap
 
 ### Fixed
 - wireguard cleanup now removes the MASQUERADE iptables rule using `${ uplink_interface }` instead of a hardcoded `eth0`, so hosts whose uplink is `ens5` / `enp0s*` / etc. no longer leak NAT rules

--- a/federated-container/modules/networking/network.js
+++ b/federated-container/modules/networking/network.js
@@ -118,8 +118,8 @@ export async function get_free_interfaces( { log_tag=uuidv4(), verbose } ) {
     // Generators
     const mk_interface_id = () => `tpn${ random_string_of_length( 5 ) }`
     const mk_veth_id = () => `tpn${ random_string_of_length( 5 ) }`
-    // Subnet pool yields {2..254} on purpose: .1 is reserved for the host side of the veth pair, .255 is broadcast
-    const mk_subnet_prefix = () => `10.200.${ random_number_between( 1, 254 ) }`
+    // Subnet selector for `10.200.X.0/24` — any value in {1..255} is a valid /24 in RFC1918 space (.1/.255 reservations apply within each /24, not to the selector)
+    const mk_subnet_prefix = () => `10.200.${ random_number_between( 255 ) }`
     const mk_namespace_id = () => `ns_${ mk_interface_id() }`
 
     // Host level info

--- a/federated-container/modules/networking/network.js
+++ b/federated-container/modules/networking/network.js
@@ -118,6 +118,7 @@ export async function get_free_interfaces( { log_tag=uuidv4(), verbose } ) {
     // Generators
     const mk_interface_id = () => `tpn${ random_string_of_length( 5 ) }`
     const mk_veth_id = () => `tpn${ random_string_of_length( 5 ) }`
+    // Subnet pool yields {2..254} on purpose: .1 is reserved for the host side of the veth pair, .255 is broadcast
     const mk_subnet_prefix = () => `10.200.${ random_number_between( 1, 254 ) }`
     const mk_namespace_id = () => `ns_${ mk_interface_id() }`
 

--- a/federated-container/modules/networking/wireguard.js
+++ b/federated-container/modules/networking/wireguard.js
@@ -452,7 +452,7 @@ export async function test_wireguard_connection( { wireguard_config, claimed_wor
         ip link del veth${ veth_id }n || echo "Veth ${ veth_id }n does not exist"
         ip link del ${ interface_id } || echo "Interface ${ interface_id } does not exist"
         ip netns del ${ namespace_id } || echo "Namespace ${ namespace_id } does not exist"
-        iptables -t nat -D POSTROUTING -s ${ veth_subnet_prefix }.0/24 -o eth0 -j MASQUERADE || echo "iptables rule does not exist"
+        iptables -t nat -D POSTROUTING -s ${ veth_subnet_prefix }.0/24 -o ${ uplink_interface } -j MASQUERADE || echo "iptables rule does not exist"
         iptables -D FORWARD -i veth${ veth_id }h -o ${ uplink_interface } -s ${ veth_subnet_prefix }.0/24 -j ACCEPT || echo "iptables rule does not exist"
         iptables -D FORWARD -o veth${ veth_id }h -m state --state ESTABLISHED,RELATED -j ACCEPT || echo "iptables rule does not exist"
         rm -f ${ tmp_config_path } || echo "Config file ${ tmp_config_path } does not exist"

--- a/federated-container/modules/scoring/query_workers.js
+++ b/federated-container/modules/scoring/query_workers.js
@@ -20,8 +20,8 @@ export async function add_configs_to_workers( { workers, mining_pool_uid, mining
     const { worker_mode, miner_mode, validator_mode } = run_mode()
 
     // Default elapsed_s function if none provided
-    const start = Date.now()
-    const get_elapsed = elapsed_s || ( () => round_number_to_decimals( ( Date.now() - start ) / 1000, 2 ) )
+    const start = performance.now()
+    const get_elapsed = elapsed_s || ( () => round_number_to_decimals( ( performance.now() - start ) / 1000, 2 ) )
 
     // Helper for optional tracing
     const trace = message => {

--- a/federated-container/modules/scoring/score_mining_pools.js
+++ b/federated-container/modules/scoring/score_mining_pools.js
@@ -9,6 +9,13 @@ import { read_mining_pool_metadata, write_pool_score } from "../database/mining_
 import { get_miners } from "../networking/miners.js"
 import { score_node_version } from "./score_node.js"
 import { is_partnered_pool } from "../partnered_pools.js"
+import {
+    AUDIT_WORKER_VALIDATION_CONCURRENCY,
+    DEFAULT_WORKER_VALIDATION_CONCURRENCY,
+    WORKER_AUDIT_ACTIVE_CACHE_KEY,
+    WORKER_SCORING_ACTIVE_CACHE_KEY,
+    WORKER_VALIDATION_COORDINATION_TTL_MS
+} from "./worker_validation_state.js"
 const { CI_MODE, CI_MOCK_MINING_POOL_RESPONSES, CI_MOCK_WORKER_RESPONSES, CI_MINER_IP_OVERRIDES } = process.env
 
 /**
@@ -216,7 +223,20 @@ async function score_single_mining_pool( { mining_pool_uid, mining_pool_ip } ) {
 
     // Score the selected workers
     cache.merge( cache_key, [ `${ elapsed_s() }s - Validating and annotating ${ workers_with_configs.length } workers for mining pool ${ pool_label }` ] )
-    const { successes, failures, workers_with_status } = await validate_and_annotate_workers( { workers_with_configs, mining_pool_uid, mining_pool_ip } )
+
+    const audit_active = cache( WORKER_AUDIT_ACTIVE_CACHE_KEY )
+    const validation_concurrency = audit_active ? AUDIT_WORKER_VALIDATION_CONCURRENCY : DEFAULT_WORKER_VALIDATION_CONCURRENCY
+    if( audit_active ) log.info( `Worker audit is active or pending, lowering scoring validation concurrency to ${ validation_concurrency }` )
+
+    let validation_result
+    cache( WORKER_SCORING_ACTIVE_CACHE_KEY, true, WORKER_VALIDATION_COORDINATION_TTL_MS )
+    try {
+        validation_result = await validate_and_annotate_workers( { workers_with_configs, mining_pool_uid, mining_pool_ip, concurrency: validation_concurrency } )
+    } finally {
+        cache( WORKER_SCORING_ACTIVE_CACHE_KEY, false )
+    }
+
+    const { successes, failures, workers_with_status } = validation_result
     cache.merge( cache_key, [ `${ elapsed_s() }s - Completed validating and annotating workers for mining pool ${ pool_label }` ] )
     log.info( `Scored workers for mining pool ${ pool_label }, successes: ${ successes?.length }, failures: ${ failures?.length }. Status annotated: ${ workers_with_status?.length }` )
     log.debug( `Failure exerpt: `, failures?.slice( 0, 3 ) )
@@ -306,4 +326,3 @@ async function score_single_mining_pool( { mining_pool_uid, mining_pool_ip } ) {
     return composite_scores
 
 }
-

--- a/federated-container/modules/scoring/score_mining_pools.js
+++ b/federated-container/modules/scoring/score_mining_pools.js
@@ -171,8 +171,8 @@ export async function score_mining_pools( max_duration_minutes=30 ) {
 async function score_single_mining_pool( { mining_pool_uid, mining_pool_ip } ) {
 
     // Prepare for scoring
-    const start = Date.now()
-    const elapsed_s = () => round_number_to_decimals( ( Date.now() - start ) / 1000, 2 )
+    const start = performance.now()
+    const elapsed_s = () => round_number_to_decimals( ( performance.now() - start ) / 1000, 2 )
     const cache_key = `score_mining_pool_${ mining_pool_uid }_${ mining_pool_ip }`
     const pool_label = `${ mining_pool_uid }@${ mining_pool_ip }`
     log.info( `Scoring mining pool ${ pool_label }` )

--- a/federated-container/modules/scoring/score_workers.js
+++ b/federated-container/modules/scoring/score_workers.js
@@ -210,7 +210,7 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
     const score_worker = async ( worker ) => {
 
         // Prepare test, set default status down, start timer
-        const start = Date.now()
+        const start = performance.now()
         const test_result = { ...worker, status: 'down' }
 
         try {
@@ -280,7 +280,7 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
             test_result.error = test_result.error || e.message
             test_result.status = test_result.status || 'down'
         } finally {
-            test_result.test_duration_s = ( Date.now() - start ) / 1_000
+            test_result.test_duration_s = ( performance.now() - start ) / 1_000
         }
         log.debug( `Worker ${ worker.ip } test result:`, test_result )
 

--- a/federated-container/modules/scoring/score_workers.js
+++ b/federated-container/modules/scoring/score_workers.js
@@ -177,7 +177,7 @@ export async function match_worker_to_pool( { worker, mining_pool_url, timeout_m
  * @param {string} params.workers_with_configs[].mining_pool_url - URL of the mining pool
  * @param {string} [params.mining_pool_uid] - UID of the mining pool (required for partnered pool detection)
  * @param {string} [params.mining_pool_ip] - IP of the mining pool (required for partnered pool detection)
- * @param {number} [params.max_worker_test_time_s=60] - Soft per-worker timeout in seconds. On expiry the worker is marked down; the underlying wireguard test still runs to completion so its slot is released cleanly.
+ * @param {number} [params.max_worker_test_time_s=60] - Soft per-worker timeout marker in seconds. The runner always awaits the underlying wireguard test (so the veth subnet slot is released before the runner moves on), but tests exceeding this threshold are flagged `down` with a timeout error. Pure observability — does not cancel the inner test or bound per-worker runtime.
  * @param {number} [params.concurrency=200] - Maximum number of workers tested in parallel. Capped below the 255-slot veth subnet pool (see network.js mk_subnet_prefix) so the orchestrator never starves the allocator.
  * @returns {Promise<Object>} Object with successes and failures arrays
  * @returns {Array} returns.successes - Array of successful worker tests
@@ -288,34 +288,29 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
 
     }
 
-    // Wrap a worker test in a soft timeout. The underlying test continues running until its own internal timeouts fire,
-    // which lets test_wireguard_connection's finally block release the veth subnet slot. We just stop waiting after the cap.
-    const score_worker_with_timeout = ( worker ) => new Promise( ( resolve, reject ) => {
-        let settled = false
-        const timer = setTimeout( () => {
-            if( settled ) return
-            settled = true
-            log.warn( `Worker ${ worker.ip } test exceeded ${ max_worker_test_time_s }s timeout, marking as down` )
-            resolve( {
-                ...worker,
-                success: false,
-                status: 'down',
-                error: `Worker test exceeded ${ max_worker_test_time_s }s timeout`,
-                test_duration_s: max_worker_test_time_s
-            } )
-        }, max_worker_test_time_s * 1000 )
-        score_worker( worker ).then( value => {
-            if( settled ) return
-            settled = true
+    // Soft-timeout marker: always awaits the underlying score_worker so the veth subnet slot is released (via
+    // test_wireguard_connection's finally → clear_interfaces) before the runner picks up the next worker.
+    // Cancelling the inner test would orphan its slot in the 255-slot pool — we intentionally wait for natural
+    // completion to keep the concurrency cap honest. The timeout flag here is purely observational.
+    const score_worker_with_timeout = async ( worker ) => {
+        let timed_out = false
+        const timer = setTimeout( () => { timed_out = true }, max_worker_test_time_s * 1000 )
+        try {
+            const result = await score_worker( worker )
+            if( timed_out ) {
+                log.warn( `Worker ${ worker.ip } test exceeded ${ max_worker_test_time_s }s soft timeout, marking as down` )
+                return {
+                    ...result,
+                    success: false,
+                    status: 'down',
+                    error: `Worker test exceeded ${ max_worker_test_time_s }s soft timeout`
+                }
+            }
+            return result
+        } finally {
             clearTimeout( timer )
-            resolve( value )
-        } ).catch( reason => {
-            if( settled ) return
-            settled = true
-            clearTimeout( timer )
-            reject( reason )
-        } )
-    } )
+        }
+    }
 
     // Run worker scoring with a concurrency cap. Each runner pulls from a shared queue until empty.
     // Output is shaped like Promise.allSettled output so the downstream reducer keeps working unchanged.

--- a/federated-container/modules/scoring/score_workers.js
+++ b/federated-container/modules/scoring/score_workers.js
@@ -294,7 +294,9 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
     // completion to keep the concurrency cap honest. The timeout flag here is purely observational.
     const score_worker_with_timeout = async ( worker ) => {
         let timed_out = false
-        const timer = setTimeout( () => { timed_out = true }, max_worker_test_time_s * 1000 )
+        const timer = setTimeout( () => {
+            timed_out = true
+        }, max_worker_test_time_s * 1000 )
         try {
             const result = await score_worker( worker )
             if( timed_out ) {
@@ -314,18 +316,18 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
 
     // Run worker scoring with a concurrency cap. Each runner pulls from a shared queue until empty.
     // Output is shaped like Promise.allSettled output so the downstream reducer keeps working unchanged.
-    const queue = valid_workers.slice()
-    const workers_test_results = []
+    const queue = valid_workers.map( ( worker, index ) => ( { worker, index } ) )
+    const workers_test_results = Array( valid_workers.length )
     const runner_count = Math.min( concurrency, queue.length )
     log.info( `Scoring ${ queue.length } workers with concurrency ${ runner_count } and per-worker timeout ${ max_worker_test_time_s }s` )
     const runners = Array( runner_count ).fill( 0 ).map( async () => {
         while( queue.length > 0 ) {
-            const worker = queue.shift()
+            const { worker, index } = queue.shift()
             try {
                 const value = await score_worker_with_timeout( worker )
-                workers_test_results.push( { status: 'fulfilled', value } )
+                workers_test_results[ index ] = { status: 'fulfilled', value }
             } catch ( reason ) {
-                workers_test_results.push( { status: 'rejected', reason } )
+                workers_test_results[ index ] = { status: 'rejected', reason }
             }
         }
     } )

--- a/federated-container/modules/scoring/score_workers.js
+++ b/federated-container/modules/scoring/score_workers.js
@@ -177,20 +177,17 @@ export async function match_worker_to_pool( { worker, mining_pool_url, timeout_m
  * @param {string} params.workers_with_configs[].mining_pool_url - URL of the mining pool
  * @param {string} [params.mining_pool_uid] - UID of the mining pool (required for partnered pool detection)
  * @param {string} [params.mining_pool_ip] - IP of the mining pool (required for partnered pool detection)
+ * @param {number} [params.max_worker_test_time_s=60] - Soft per-worker timeout in seconds. On expiry the worker is marked down; the underlying wireguard test still runs to completion so its slot is released cleanly.
+ * @param {number} [params.concurrency=200] - Maximum number of workers tested in parallel. Capped below the ~253-slot veth subnet pool (see network.js mk_subnet_prefix) so the orchestrator never starves the allocator.
  * @returns {Promise<Object>} Object with successes and failures arrays
  * @returns {Array} returns.successes - Array of successful worker tests
  * @returns {Array} returns.failures - Array of failed worker tests
  */
-export async function validate_and_annotate_workers( { workers_with_configs=[], mining_pool_uid, mining_pool_ip } ) {
+export async function validate_and_annotate_workers( { workers_with_configs=[], mining_pool_uid, mining_pool_ip, max_worker_test_time_s=60, concurrency=200 } ) {
 
     // Partnered pool workers run custom code — version and membership checks call workers directly and must be skipped
     const is_partnered = mining_pool_uid && mining_pool_ip && is_partnered_pool( { mining_pool_uid, mining_pool_ip } )
     if( is_partnered ) log.info( `Pool ${ mining_pool_uid } is a partnered network pool, skipping version and membership checks for ${ workers_with_configs.length } workers` )
-
-    // If worker config list exceeds 250, warn this is close to ip subnet limit and might cause issues
-    if( workers_with_configs.length > 250 ) {
-        log.warn( `Worker config list exceeds 250, this may cause issues with IP subnet limits` )
-    }
 
     if( CI_MODE === 'true' ) log.info( `Validating ${ workers_with_configs?.length } workers, first:`, workers_with_configs?.[0] )
 
@@ -209,15 +206,15 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
 
     }, [ [], [] ] )
 
-    // Score the selected workers
-    const scoring_queue = valid_workers.map( async worker => {
+    // Score a single worker — runs the full battery of checks and returns a test_result shaped object
+    const score_worker = async ( worker ) => {
 
         // Prepare test, set default status down, start timer
         const start = Date.now()
         const test_result = { ...worker, status: 'down' }
 
         try {
-    
+
             // Start test
             const { text_config, mining_pool_url } = worker
             if( CI_MODE === 'true' ) log.info( `Validating worker ${ worker.ip } with config:`, worker )
@@ -249,7 +246,7 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
                 throw new Error( `Wireguard config invalid for ${ worker.ip }: ${ message }` )
             }
 
-    
+
             // Test the socks5 config works
             const { socks5_config: sock } = worker
             const socks5_validation = await test_socks5_connection( { sock, claimed_worker_ip: worker.ip } )
@@ -272,7 +269,7 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
             test_result.country_code = country_code
             test_result.datacenter = datacenter
             test_result.connection_type = connection_type
-    
+
             // Set test result
             test_result.success = true
             test_result.status = 'up'
@@ -288,11 +285,56 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
         log.debug( `Worker ${ worker.ip } test result:`, test_result )
 
         return test_result
-    
+
+    }
+
+    // Wrap a worker test in a soft timeout. The underlying test continues running until its own internal timeouts fire,
+    // which lets test_wireguard_connection's finally block release the veth subnet slot. We just stop waiting after the cap.
+    const score_worker_with_timeout = ( worker ) => new Promise( ( resolve, reject ) => {
+        let settled = false
+        const timer = setTimeout( () => {
+            if( settled ) return
+            settled = true
+            log.warn( `Worker ${ worker.ip } test exceeded ${ max_worker_test_time_s }s timeout, marking as down` )
+            resolve( {
+                ...worker,
+                success: false,
+                status: worker.status || 'down',
+                error: `Worker test exceeded ${ max_worker_test_time_s }s timeout`,
+                test_duration_s: max_worker_test_time_s
+            } )
+        }, max_worker_test_time_s * 1000 )
+        score_worker( worker ).then( value => {
+            if( settled ) return
+            settled = true
+            clearTimeout( timer )
+            resolve( value )
+        } ).catch( reason => {
+            if( settled ) return
+            settled = true
+            clearTimeout( timer )
+            reject( reason )
+        } )
     } )
-    
-    // Wait for all workers to be scored
-    let workers_test_results = await Promise.allSettled( scoring_queue )
+
+    // Run worker scoring with a concurrency cap. Each runner pulls from a shared queue until empty.
+    // Output is shaped like Promise.allSettled output so the downstream reducer keeps working unchanged.
+    const queue = valid_workers.slice()
+    const workers_test_results = []
+    const runner_count = Math.min( concurrency, queue.length )
+    log.info( `Scoring ${ queue.length } workers with concurrency ${ runner_count } and per-worker timeout ${ max_worker_test_time_s }s` )
+    const runners = Array( runner_count ).fill( 0 ).map( async () => {
+        while( queue.length > 0 ) {
+            const worker = queue.shift()
+            try {
+                const value = await score_worker_with_timeout( worker )
+                workers_test_results.push( { status: 'fulfilled', value } )
+            } catch ( reason ) {
+                workers_test_results.push( { status: 'rejected', reason } )
+            }
+        }
+    } )
+    await Promise.all( runners )
     const [ successes, failures ] = workers_test_results.reduce( ( acc, promise_test_result_obj ) => {
     
         const { status, value: test_result={}, reason } = promise_test_result_obj

--- a/federated-container/modules/scoring/score_workers.js
+++ b/federated-container/modules/scoring/score_workers.js
@@ -178,7 +178,7 @@ export async function match_worker_to_pool( { worker, mining_pool_url, timeout_m
  * @param {string} [params.mining_pool_uid] - UID of the mining pool (required for partnered pool detection)
  * @param {string} [params.mining_pool_ip] - IP of the mining pool (required for partnered pool detection)
  * @param {number} [params.max_worker_test_time_s=60] - Soft per-worker timeout in seconds. On expiry the worker is marked down; the underlying wireguard test still runs to completion so its slot is released cleanly.
- * @param {number} [params.concurrency=200] - Maximum number of workers tested in parallel. Capped below the ~253-slot veth subnet pool (see network.js mk_subnet_prefix) so the orchestrator never starves the allocator.
+ * @param {number} [params.concurrency=200] - Maximum number of workers tested in parallel. Capped below the 255-slot veth subnet pool (see network.js mk_subnet_prefix) so the orchestrator never starves the allocator.
  * @returns {Promise<Object>} Object with successes and failures arrays
  * @returns {Array} returns.successes - Array of successful worker tests
  * @returns {Array} returns.failures - Array of failed worker tests
@@ -299,7 +299,7 @@ export async function validate_and_annotate_workers( { workers_with_configs=[], 
             resolve( {
                 ...worker,
                 success: false,
-                status: worker.status || 'down',
+                status: 'down',
                 error: `Worker test exceeded ${ max_worker_test_time_s }s timeout`,
                 test_duration_s: max_worker_test_time_s
             } )

--- a/federated-container/modules/scoring/worker_validation_state.js
+++ b/federated-container/modules/scoring/worker_validation_state.js
@@ -1,0 +1,9 @@
+export const WORKER_AUDIT_ACTIVE_CACHE_KEY = `worker_audit_active_or_pending`
+export const WORKER_SCORING_ACTIVE_CACHE_KEY = `worker_scoring_active`
+
+export const WORKER_VALIDATION_COORDINATION_TTL_MS = 60 * 60_000
+export const AUDIT_SCORING_WAIT_INTERVAL_MS = 30_000
+export const AUDIT_SCORING_MAX_WAIT_MS = 15 * 60_000
+
+export const DEFAULT_WORKER_VALIDATION_CONCURRENCY = 200
+export const AUDIT_WORKER_VALIDATION_CONCURRENCY = 100

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package-lock.json
+++ b/federated-container/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tpn-node",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tpn-node",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "dependencies": {
         "@fast-csv/format": "^5.0.5",
         "@maxmind/geoip2-node": "^6.3.4",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/package.json
+++ b/federated-container/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tpn-node",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "TPN Node docker container code, used for validators, miners, and workers",
   "main": "app.js",
   "type": "module",

--- a/federated-container/routes/validator/score.js
+++ b/federated-container/routes/validator/score.js
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { score_mining_pools } from "../../modules/scoring/score_mining_pools.js"
-import { cache, log } from "mentie"
+import { cache, log, wait } from "mentie"
 import { get_pool_scores } from "../../modules/database/mining_pools.js"
 import { request_is_local } from "../../modules/networking/network.js"
 import { get_workers } from "../../modules/database/workers.js"
@@ -9,6 +9,14 @@ import { validate_and_annotate_workers, match_worker_to_pool } from "../../modul
 import { get_worker_config_as_validator } from "../../modules/api/validator.js"
 import { get_tpn_cache } from "../../modules/caching.js"
 import { is_partnered_pool } from "../../modules/partnered_pools.js"
+import {
+    AUDIT_SCORING_MAX_WAIT_MS,
+    AUDIT_SCORING_WAIT_INTERVAL_MS,
+    AUDIT_WORKER_VALIDATION_CONCURRENCY,
+    WORKER_AUDIT_ACTIVE_CACHE_KEY,
+    WORKER_SCORING_ACTIVE_CACHE_KEY,
+    WORKER_VALIDATION_COORDINATION_TTL_MS
+} from "../../modules/scoring/worker_validation_state.js"
 
 
 export const router = Router()
@@ -80,6 +88,10 @@ router.get( '/audit/:pool_uid', async ( req, res ) => {
     if( !ADMIN_API_KEY ) return res.status( 403 ).json( { error: `ADMIN_API_KEY not configured` } )
     if( api_key !== ADMIN_API_KEY ) return res.status( 403 ).json( { error: `Invalid API key` } )
 
+    // Prevent concurrent audits. The audit key means active or pending, so future scoring runs lower concurrency while this request waits.
+    const audit_locked = cache( WORKER_AUDIT_ACTIVE_CACHE_KEY )
+    if( audit_locked ) return res.status( 429 ).json( { error: `Worker audit already in progress` } )
+
     // Prevent concurrent audits for the same pool
     const lock_key = `audit_pool_${ pool_uid }_running`
     const locked = cache( lock_key )
@@ -87,10 +99,21 @@ router.get( '/audit/:pool_uid', async ( req, res ) => {
 
     try {
 
-        // Set lock for 15 minutes max duration
-        cache( lock_key, true, 15 * 60_000 )
+        // Set locks with a TTL so abandoned requests do not permanently block audits or throttle scoring
+        cache( WORKER_AUDIT_ACTIVE_CACHE_KEY, true, WORKER_VALIDATION_COORDINATION_TTL_MS )
+        cache( lock_key, true, WORKER_VALIDATION_COORDINATION_TTL_MS )
 
         log.info( `Starting audit for pool ${ pool_uid }` )
+
+        // If scoring is already validating workers, wait for that batch to drain before this audit starts.
+        const wait_started_at = Date.now()
+        while( cache( WORKER_SCORING_ACTIVE_CACHE_KEY ) ) {
+            const elapsed_ms = Date.now() - wait_started_at
+            if( elapsed_ms > AUDIT_SCORING_MAX_WAIT_MS ) throw new Error( `Timed out waiting for worker scoring validation to finish before audit` )
+
+            log.info( `Audit for pool ${ pool_uid } waiting ${ AUDIT_SCORING_WAIT_INTERVAL_MS / 1_000 }s for worker scoring validation to finish` )
+            await wait( AUDIT_SCORING_WAIT_INTERVAL_MS )
+        }
 
         // Get workers for this pool
         const { workers } = await get_workers( { mining_pool_uid: pool_uid } )
@@ -143,7 +166,7 @@ router.get( '/audit/:pool_uid', async ( req, res ) => {
         } ) )
 
         // Test all workers (partnered pools skip version + membership checks in validate_and_annotate_workers)
-        const { successes, failures } = await validate_and_annotate_workers( { workers_with_configs: workers_to_validate, mining_pool_uid: pool_uid, mining_pool_ip } )
+        const { successes, failures } = await validate_and_annotate_workers( { workers_with_configs: workers_to_validate, mining_pool_uid: pool_uid, mining_pool_ip, concurrency: AUDIT_WORKER_VALIDATION_CONCURRENCY } )
 
         // Calculate uptime percentage based on verified members only
         const total = workers_to_validate.length
@@ -179,8 +202,9 @@ router.get( '/audit/:pool_uid', async ( req, res ) => {
         return res.status( 500 ).json( { error: e.message } )
     } finally {
 
-        // Release lock
+        // Release locks
         cache( lock_key, false )
+        cache( WORKER_AUDIT_ACTIVE_CACHE_KEY, false )
 
     }
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -18,15 +18,12 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-import os
 import time
-import datetime
 import logging
 import requests
 
 # Bittensor
 import bittensor as bt
-import wandb
 
 # import base validator class which takes care of most of the boilerplate
 from sybil.base.validator import BaseValidatorNeuron
@@ -75,43 +72,6 @@ class Validator(BaseValidatorNeuron):
             pass
 
         bt.logging.info(f"===> Validator initialized: {self.step}, {len(self.scores)}, {len(self.hotkeys)}")
-
-        self.wandb_run_start = None
-        if not self.config.wandb.off:
-            if os.getenv("WANDB_API_KEY"):
-                self.new_wandb_run()
-            else:
-                bt.logging.exception(
-                    "WANDB_API_KEY not found. Set it with `export WANDB_API_KEY=<your API key>`. Alternatively, you can disable W&B with --wandb.off, but it is strongly recommended to run with W&B enabled."
-                )
-                self.config.wandb.off = True
-        else:
-            bt.logging.warning(
-                "Running with --wandb.off. It is strongly recommended to run with W&B enabled."
-            )
-
-    def new_wandb_run(self):
-        """Creates a new wandb run to save information to."""
-        # Create a unique run id for this run.
-        now = datetime.datetime.now()
-        self.wandb_run_start = now
-        run_id = now.strftime("%Y-%m-%d_%H-%M-%S")
-        name = "validator-" + str(self.uid) + "-" + run_id
-        self.wandb_run = wandb.init(
-            name=name,
-            project="tpn-validators",
-            entity="tpn-subnet",
-            config={
-                "uid": self.uid,
-                "hotkey": self.wallet.hotkey.ss58_address,
-                "run_name": run_id,
-                "type": "validator",
-            },
-            allow_val_change=True,
-            anonymous="allow",
-        )
-
-        bt.logging.debug(f"Started a new wandb run: {name}")
 
     async def forward(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ rich>=13
 pytest>=8
 numpy>=1
 setuptools>=68
-wandb==0.19.6
 bittensor-cli>=9.17.0

--- a/scripts/update_node.sh
+++ b/scripts/update_node.sh
@@ -454,7 +454,6 @@ if [ "$RUN_MODE" != "worker" ]; then
         TPN_CACHE="$HOME/.tpn_cache"
         mkdir -p "$TPN_CACHE"
         export TMPDIR=$TPN_CACHE
-        export WANDB_CACHE_DIR=$TPN_CACHE
 
         echo "Installing Python dependencies..."
         if ! pip install -r requirements.txt; then

--- a/sybil/utils/config.py
+++ b/sybil/utils/config.py
@@ -109,27 +109,6 @@ def add_args(cls, parser):
         default=False,
     )
 
-    parser.add_argument(
-        "--wandb.off",
-        action="store_true",
-        help="Turn off wandb.",
-        default=False,
-    )
-
-    parser.add_argument(
-        "--wandb.offline",
-        action="store_true",
-        help="Runs wandb in offline mode.",
-        default=False,
-    )
-
-    parser.add_argument(
-        "--wandb.notes",
-        type=str,
-        help="Notes to add to the wandb run.",
-        default="",
-    )
-
 
 def add_miner_args(cls, parser):
     """Add miner specific arguments to the parser."""
@@ -155,20 +134,6 @@ def add_miner_args(cls, parser):
         default=False,
     )
 
-    parser.add_argument(
-        "--wandb.project_name",
-        type=str,
-        default="sybil-miners",
-        help="Wandb project to log to.",
-    )
-
-    parser.add_argument(
-        "--wandb.entity",
-        type=str,
-        default="opentensor-dev",
-        help="Wandb entity to log to.",
-    )
-    
     parser.add_argument(
         "--miner.server",
         type=str,
@@ -237,20 +202,6 @@ def add_validator_args(cls, parser):
         type=int,
         help="The maximum number of TAO allowed to query a validator with a vpermit.",
         default=4096,
-    )
-
-    parser.add_argument(
-        "--wandb.project_name",
-        type=str,
-        help="The name of the project where you are sending the new run.",
-        default="sybil-validators",
-    )
-
-    parser.add_argument(
-        "--wandb.entity",
-        type=str,
-        help="The name of the project where you are sending the new run.",
-        default="opentensor-dev",
     )
 
     parser.add_argument(

--- a/sybil/utils/http.py
+++ b/sybil/utils/http.py
@@ -56,7 +56,7 @@ async def _retry_with_backoff( func, *args, max_retries: int = MAX_RETRIES, **kw
                 wait_time = min( delay + jitter, MAX_DELAY )
                 bt.logging.warning(
                     f"HTTP request failed (attempt { attempt + 1 }/{ max_retries }): { e }. "
-                    f"Retrying in { wait_time:.1f }s..."
+                    f"Retrying in { wait_time:.1f}s..."
                 )
                 await asyncio.sleep( wait_time )
                 delay *= BACKOFF_MULTIPLIER


### PR DESCRIPTION
 - Removes the unused W&B validator integration, dependency, CLI config, cache env setup, and validator setup docs.
  - Caps worker validation concurrency so large pools do not exhaust the veth subnet allocator, while preserving result order.
  - Coordinates validator audits with active scoring runs: audits are globally exclusive, wait for active scoring validation to drain, and use
  lower validation concurrency.
  - Switches scoring timers to monotonic `performance.now()` to avoid negative durations from wall-clock changes.
  - Fixes WireGuard cleanup to remove MASQUERADE rules using the detected uplink interface instead of hardcoded `eth0`.
  - Bumps `federated-container` to `1.10.1` and updates the changelog.
